### PR TITLE
Initialize bun library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# dependencies (bun install)
+node_modules
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # gleam-js
+
 A wrapper around window, document, event, etc. to be called from Gleam.
+
+This project uses [Bun](https://bun.sh) to build a small TypeScript library.
+
+## Development
+
+Install dependencies:
+
+```bash
+bun install
+```
+
+Build the library:
+
+```bash
+bun run build
+```
+
+## Publishing
+
+Make sure the `dist` directory is present and then publish to npm:
+
+```bash
+npm publish
+```

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+entrypoints = ["src/index.ts"]
+outdir = "dist"
+minify = true
+target = "node"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "gleam-js",
+  "version": "0.1.0",
+  "description": "A wrapper around window, document, event, etc. to be called from Gleam.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": "./dist/index.js",
+  "files": ["dist"],
+  "scripts": {
+    "build": "bun build",
+    "prepublishOnly": "bun run build"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,7 @@
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+export default {
+  greet,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
## Summary
- initialize bun project for building a TypeScript library
- configure `bunfig.toml` for bundling source to `dist`
- add package metadata and build scripts
- document setup and publishing instructions in README

## Testing
- `bun install` *(fails: ConnectionRefused)*