### PR TITLE
Add window and document modules with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "type": "module",
   "main": "./dist/index.js",
   "exports": "./dist/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "bun build",
-    "prepublishOnly": "bun run build"
+    "build": "bun build src/index.ts --outdir dist --target node --minify",
+    "prepublishOnly": "bun run build",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -1,0 +1,19 @@
+export function Document(): unknown {
+  return (globalThis as any).Document;
+}
+
+export function activeElement(): unknown {
+  return (globalThis as any).document?.activeElement;
+}
+
+export function adoptedStyleSheets(): unknown {
+  return (globalThis as any).document?.adoptedStyleSheets;
+}
+
+export function body(): unknown {
+  return (globalThis as any).document?.body;
+}
+
+export function characterSet(): string | undefined {
+  return (globalThis as any).document?.characterSet;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,2 @@
-export function greet(name: string): string {
-  return `Hello, ${name}!`;
-}
-
-export default {
-  greet,
-};
+export * as window from "./window";
+export * as document from "./document";

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1,0 +1,19 @@
+export function caches(): unknown {
+  return (globalThis as any).caches;
+}
+
+export function clientInformation(): unknown {
+  return (globalThis as any).clientInformation;
+}
+
+export function closed(): boolean {
+  return (globalThis as any).closed;
+}
+
+export function cookieStore(): unknown {
+  return (globalThis as any).cookieStore;
+}
+
+export function credentialless(): boolean {
+  return (globalThis as any).credentialless;
+}

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -1,0 +1,28 @@
+import { Document, activeElement, adoptedStyleSheets, body, characterSet } from "../src/document";
+import { expect, test } from "bun:test";
+
+test("Document returns global Document", () => {
+  function MyDoc() {}
+  (globalThis as any).Document = MyDoc;
+  expect(Document()).toBe(MyDoc);
+});
+
+test("activeElement returns document.activeElement", () => {
+  (globalThis as any).document = { activeElement: "el" };
+  expect(activeElement()).toBe("el");
+});
+
+test("adoptedStyleSheets returns document.adoptedStyleSheets", () => {
+  (globalThis as any).document = { adoptedStyleSheets: [1,2,3] };
+  expect(adoptedStyleSheets()).toEqual([1,2,3]);
+});
+
+test("body returns document.body", () => {
+  (globalThis as any).document = { body: "b" };
+  expect(body()).toBe("b");
+});
+
+test("characterSet returns document.characterSet", () => {
+  (globalThis as any).document = { characterSet: "UTF-8" };
+  expect(characterSet()).toBe("UTF-8");
+});

--- a/tests/window.test.ts
+++ b/tests/window.test.ts
@@ -1,0 +1,27 @@
+import { caches, clientInformation, closed, cookieStore, credentialless } from "../src/window";
+import { expect, test } from "bun:test";
+
+test("caches returns global caches", () => {
+  (globalThis as any).caches = "CACHES_TEST";
+  expect(caches()).toBe("CACHES_TEST");
+});
+
+test("clientInformation returns global clientInformation", () => {
+  (globalThis as any).clientInformation = { info: true };
+  expect(clientInformation()).toEqual({ info: true });
+});
+
+test("closed returns global closed", () => {
+  (globalThis as any).closed = true;
+  expect(closed()).toBe(true);
+});
+
+test("cookieStore returns global cookieStore", () => {
+  (globalThis as any).cookieStore = { store: 1 };
+  expect(cookieStore()).toEqual({ store: 1 });
+});
+
+test("credentialless returns global credentialless", () => {
+  (globalThis as any).credentialless = false;
+  expect(credentialless()).toBe(false);
+});


### PR DESCRIPTION
## Summary
- organize window and document wrappers into dedicated modules
- remove old `greet` export and re-export the modules from `index.ts`
- add regression tests for these wrappers using Bun
- update build script and add test script

## Testing
- `bun run build`
- `bun test`
