### PR TITLE
Add missing DOM wrappers with tests

### DIFF
--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -17,3 +17,23 @@ export function body(): unknown {
 export function characterSet(): string | undefined {
   return (globalThis as any).document?.characterSet;
 }
+
+export function childElementCount(): number | undefined {
+  return (globalThis as any).document?.childElementCount;
+}
+
+export function children(): unknown {
+  return (globalThis as any).document?.children;
+}
+
+export function compatMode(): string | undefined {
+  return (globalThis as any).document?.compatMode;
+}
+
+export function contentType(): string | undefined {
+  return (globalThis as any).document?.contentType;
+}
+
+export function currentScript(): unknown {
+  return (globalThis as any).document?.currentScript;
+}

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -17,3 +17,23 @@ export function cookieStore(): unknown {
 export function credentialless(): boolean {
   return (globalThis as any).credentialless;
 }
+
+export function crossOriginIsolated(): boolean {
+  return (globalThis as any).crossOriginIsolated;
+}
+
+export function crypto(): unknown {
+  return (globalThis as any).crypto;
+}
+
+export function customElements(): unknown {
+  return (globalThis as any).customElements;
+}
+
+export function devicePixelRatio(): number {
+  return (globalThis as any).devicePixelRatio;
+}
+
+export function document(): unknown {
+  return (globalThis as any).document;
+}

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -1,4 +1,15 @@
-import { Document, activeElement, adoptedStyleSheets, body, characterSet } from "../src/document";
+import {
+  Document,
+  activeElement,
+  adoptedStyleSheets,
+  body,
+  characterSet,
+  childElementCount,
+  children,
+  compatMode,
+  contentType,
+  currentScript,
+} from "../src/document";
 import { expect, test } from "bun:test";
 
 test("Document returns global Document", () => {
@@ -25,4 +36,29 @@ test("body returns document.body", () => {
 test("characterSet returns document.characterSet", () => {
   (globalThis as any).document = { characterSet: "UTF-8" };
   expect(characterSet()).toBe("UTF-8");
+});
+
+test("childElementCount returns document.childElementCount", () => {
+  (globalThis as any).document = { childElementCount: 5 };
+  expect(childElementCount()).toBe(5);
+});
+
+test("children returns document.children", () => {
+  (globalThis as any).document = { children: ["a", "b"] };
+  expect(children()).toEqual(["a", "b"]);
+});
+
+test("compatMode returns document.compatMode", () => {
+  (globalThis as any).document = { compatMode: "CSS1Compat" };
+  expect(compatMode()).toBe("CSS1Compat");
+});
+
+test("contentType returns document.contentType", () => {
+  (globalThis as any).document = { contentType: "text/html" };
+  expect(contentType()).toBe("text/html");
+});
+
+test("currentScript returns document.currentScript", () => {
+  (globalThis as any).document = { currentScript: "script.js" };
+  expect(currentScript()).toBe("script.js");
 });

--- a/tests/window.test.ts
+++ b/tests/window.test.ts
@@ -1,4 +1,15 @@
-import { caches, clientInformation, closed, cookieStore, credentialless } from "../src/window";
+import {
+  caches,
+  clientInformation,
+  closed,
+  cookieStore,
+  credentialless,
+  crossOriginIsolated,
+  crypto,
+  customElements,
+  devicePixelRatio,
+  document,
+} from "../src/window";
 import { expect, test } from "bun:test";
 
 test("caches returns global caches", () => {
@@ -24,4 +35,29 @@ test("cookieStore returns global cookieStore", () => {
 test("credentialless returns global credentialless", () => {
   (globalThis as any).credentialless = false;
   expect(credentialless()).toBe(false);
+});
+
+test("crossOriginIsolated returns global crossOriginIsolated", () => {
+  (globalThis as any).crossOriginIsolated = true;
+  expect(crossOriginIsolated()).toBe(true);
+});
+
+test("crypto returns global crypto", () => {
+  (globalThis as any).crypto = { crypt: 1 };
+  expect(crypto()).toEqual({ crypt: 1 });
+});
+
+test("customElements returns global customElements", () => {
+  (globalThis as any).customElements = { ce: 2 };
+  expect(customElements()).toEqual({ ce: 2 });
+});
+
+test("devicePixelRatio returns global devicePixelRatio", () => {
+  (globalThis as any).devicePixelRatio = 2;
+  expect(devicePixelRatio()).toBe(2);
+});
+
+test("document returns global document", () => {
+  (globalThis as any).document = { doc: true };
+  expect(document()).toEqual({ doc: true });
 });


### PR DESCRIPTION
## Summary
- add wrappers for `window` properties: crossOriginIsolated, crypto, customElements, devicePixelRatio, and document
- add wrappers for `document` properties: childElementCount, children, compatMode, contentType, and currentScript
- include regression tests for new wrappers

## Testing
- `npm test`
