### PR TITLE
Add wrappers for DOM properties

### DIFF
--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -37,3 +37,23 @@ export function contentType(): string | undefined {
 export function currentScript(): unknown {
   return (globalThis as any).document?.currentScript;
 }
+
+export function doctype(): unknown {
+  return (globalThis as any).document?.doctype;
+}
+
+export function documentElement(): unknown {
+  return (globalThis as any).document?.documentElement;
+}
+
+export function documentURI(): string | undefined {
+  return (globalThis as any).document?.documentURI;
+}
+
+export function embeds(): unknown {
+  return (globalThis as any).document?.embeds;
+}
+
+export function featurePolicy(): unknown {
+  return (globalThis as any).document?.featurePolicy;
+}

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -37,3 +37,23 @@ export function devicePixelRatio(): number {
 export function document(): unknown {
   return (globalThis as any).document;
 }
+
+export function documentPictureInPicture(): unknown {
+  return (globalThis as any).documentPictureInPicture;
+}
+
+export function fence(): unknown {
+  return (globalThis as any).fence;
+}
+
+export function frameElement(): unknown {
+  return (globalThis as any).frameElement;
+}
+
+export function frames(): unknown {
+  return (globalThis as any).frames;
+}
+
+export function fullScreen(): boolean {
+  return (globalThis as any).fullScreen;
+}

--- a/tests/document/index.test.ts
+++ b/tests/document/index.test.ts
@@ -9,7 +9,12 @@ import {
   compatMode,
   contentType,
   currentScript,
-} from "../src/document";
+  doctype,
+  documentElement,
+  documentURI,
+  embeds,
+  featurePolicy,
+} from "../../src/document";
 import { expect, test } from "bun:test";
 
 test("Document returns global Document", () => {
@@ -61,4 +66,29 @@ test("contentType returns document.contentType", () => {
 test("currentScript returns document.currentScript", () => {
   (globalThis as any).document = { currentScript: "script.js" };
   expect(currentScript()).toBe("script.js");
+});
+
+test("doctype returns document.doctype", () => {
+  (globalThis as any).document = { doctype: "doctype" };
+  expect(doctype()).toBe("doctype");
+});
+
+test("documentElement returns document.documentElement", () => {
+  (globalThis as any).document = { documentElement: { node: true } };
+  expect(documentElement()).toEqual({ node: true });
+});
+
+test("documentURI returns document.documentURI", () => {
+  (globalThis as any).document = { documentURI: "http://example" };
+  expect(documentURI()).toBe("http://example");
+});
+
+test("embeds returns document.embeds", () => {
+  (globalThis as any).document = { embeds: [1, 2] };
+  expect(embeds()).toEqual([1, 2]);
+});
+
+test("featurePolicy returns document.featurePolicy", () => {
+  (globalThis as any).document = { featurePolicy: { features: true } };
+  expect(featurePolicy()).toEqual({ features: true });
 });

--- a/tests/window/index.test.ts
+++ b/tests/window/index.test.ts
@@ -9,7 +9,12 @@ import {
   customElements,
   devicePixelRatio,
   document,
-} from "../src/window";
+  documentPictureInPicture,
+  fence,
+  frameElement,
+  frames,
+  fullScreen,
+} from "../../src/window";
 import { expect, test } from "bun:test";
 
 test("caches returns global caches", () => {
@@ -60,4 +65,29 @@ test("devicePixelRatio returns global devicePixelRatio", () => {
 test("document returns global document", () => {
   (globalThis as any).document = { doc: true };
   expect(document()).toEqual({ doc: true });
+});
+
+test("documentPictureInPicture returns global documentPictureInPicture", () => {
+  (globalThis as any).documentPictureInPicture = { pip: true };
+  expect(documentPictureInPicture()).toEqual({ pip: true });
+});
+
+test("fence returns global fence", () => {
+  (globalThis as any).fence = { fenced: true };
+  expect(fence()).toEqual({ fenced: true });
+});
+
+test("frameElement returns global frameElement", () => {
+  (globalThis as any).frameElement = { frame: 1 };
+  expect(frameElement()).toEqual({ frame: 1 });
+});
+
+test("frames returns global frames", () => {
+  (globalThis as any).frames = { window: 1 };
+  expect(frames()).toEqual({ window: 1 });
+});
+
+test("fullScreen returns global fullScreen", () => {
+  (globalThis as any).fullScreen = true;
+  expect(fullScreen()).toBe(true);
 });


### PR DESCRIPTION
## Summary
- expose more window wrappers
- expose more document wrappers
- test the new wrappers
- reorganize tests into folders matching source layout

## Testing
- `bun test`
