### PR TITLE
Add wrappers for more DOM APIs

### DIFF
--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -57,3 +57,23 @@ export function embeds(): unknown {
 export function featurePolicy(): unknown {
   return (globalThis as any).document?.featurePolicy;
 }
+
+export function firstElementChild(): unknown {
+  return (globalThis as any).document?.firstElementChild;
+}
+
+export function fonts(): unknown {
+  return (globalThis as any).document?.fonts;
+}
+
+export function forms(): unknown {
+  return (globalThis as any).document?.forms;
+}
+
+export function fragmentDirective(): unknown {
+  return (globalThis as any).document?.fragmentDirective;
+}
+
+export function fullscreenElement(): unknown {
+  return (globalThis as any).document?.fullscreenElement;
+}

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -57,3 +57,27 @@ export function frames(): unknown {
 export function fullScreen(): boolean {
   return (globalThis as any).fullScreen;
 }
+
+export function history(): unknown {
+  return (globalThis as any).history;
+}
+
+export function indexedDb(): unknown {
+  return (globalThis as any).indexedDB;
+}
+
+export function innerHeight(): number {
+  return (globalThis as any).innerHeight;
+}
+
+export function innerWidth(): number {
+  return (globalThis as any).innerWidth;
+}
+
+export function isSecureContext(): boolean {
+  return (globalThis as any).isSecureContext;
+}
+
+export function launchQueue(): unknown {
+  return (globalThis as any).launchQueue;
+}

--- a/tests/document/index.test.ts
+++ b/tests/document/index.test.ts
@@ -14,6 +14,11 @@ import {
   documentURI,
   embeds,
   featurePolicy,
+  firstElementChild,
+  fonts,
+  forms,
+  fragmentDirective,
+  fullscreenElement,
 } from "../../src/document";
 import { expect, test } from "bun:test";
 
@@ -91,4 +96,29 @@ test("embeds returns document.embeds", () => {
 test("featurePolicy returns document.featurePolicy", () => {
   (globalThis as any).document = { featurePolicy: { features: true } };
   expect(featurePolicy()).toEqual({ features: true });
+});
+
+test("firstElementChild returns document.firstElementChild", () => {
+  (globalThis as any).document = { firstElementChild: { child: 1 } };
+  expect(firstElementChild()).toEqual({ child: 1 });
+});
+
+test("fonts returns document.fonts", () => {
+  (globalThis as any).document = { fonts: ["Arial"] };
+  expect(fonts()).toEqual(["Arial"]);
+});
+
+test("forms returns document.forms", () => {
+  (globalThis as any).document = { forms: [1, 2] };
+  expect(forms()).toEqual([1, 2]);
+});
+
+test("fragmentDirective returns document.fragmentDirective", () => {
+  (globalThis as any).document = { fragmentDirective: { text: "d" } };
+  expect(fragmentDirective()).toEqual({ text: "d" });
+});
+
+test("fullscreenElement returns document.fullscreenElement", () => {
+  (globalThis as any).document = { fullscreenElement: { el: true } };
+  expect(fullscreenElement()).toEqual({ el: true });
 });

--- a/tests/window/index.test.ts
+++ b/tests/window/index.test.ts
@@ -14,6 +14,12 @@ import {
   frameElement,
   frames,
   fullScreen,
+  history,
+  indexedDb,
+  innerHeight,
+  innerWidth,
+  isSecureContext,
+  launchQueue,
 } from "../../src/window";
 import { expect, test } from "bun:test";
 
@@ -90,4 +96,34 @@ test("frames returns global frames", () => {
 test("fullScreen returns global fullScreen", () => {
   (globalThis as any).fullScreen = true;
   expect(fullScreen()).toBe(true);
+});
+
+test("history returns global history", () => {
+  (globalThis as any).history = { stack: [] };
+  expect(history()).toEqual({ stack: [] });
+});
+
+test("indexedDb returns global indexedDB", () => {
+  (globalThis as any).indexedDB = { db: 1 };
+  expect(indexedDb()).toEqual({ db: 1 });
+});
+
+test("innerHeight returns global innerHeight", () => {
+  (globalThis as any).innerHeight = 480;
+  expect(innerHeight()).toBe(480);
+});
+
+test("innerWidth returns global innerWidth", () => {
+  (globalThis as any).innerWidth = 640;
+  expect(innerWidth()).toBe(640);
+});
+
+test("isSecureContext returns global isSecureContext", () => {
+  (globalThis as any).isSecureContext = true;
+  expect(isSecureContext()).toBe(true);
+});
+
+test("launchQueue returns global launchQueue", () => {
+  (globalThis as any).launchQueue = { queue: true };
+  expect(launchQueue()).toEqual({ queue: true });
 });


### PR DESCRIPTION
## Summary
- expose additional `window` APIs like `history` and `innerWidth`
- expose additional `document` APIs like `fonts` and `fullscreenElement`
- test all new wrappers

## Testing
- `bun test`