### PR TITLE
Add window/document instance helpers

### DIFF
--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -1,187 +1,374 @@
 export function Document(): unknown {
   return (globalThis as any).Document;
 }
+export function DocumentFrom(doc: any): unknown {
+  return (doc as any).Document;
+}
+
 
 export function activeElement(): unknown {
   return (globalThis as any).document?.activeElement;
 }
+export function activeElementFrom(doc: any): unknown {
+  return (doc as any).activeElement;
+}
+
 
 export function adoptedStyleSheets(): unknown {
   return (globalThis as any).document?.adoptedStyleSheets;
 }
+export function adoptedStyleSheetsFrom(doc: any): unknown {
+  return (doc as any).adoptedStyleSheets;
+}
+
 
 export function body(): unknown {
   return (globalThis as any).document?.body;
 }
+export function bodyFrom(doc: any): unknown {
+  return (doc as any).body;
+}
+
 
 export function characterSet(): string | undefined {
   return (globalThis as any).document?.characterSet;
 }
+export function characterSetFrom(doc: any): unknown {
+  return (doc as any).characterSet;
+}
+
 
 export function childElementCount(): number | undefined {
   return (globalThis as any).document?.childElementCount;
 }
+export function childElementCountFrom(doc: any): unknown {
+  return (doc as any).childElementCount;
+}
+
 
 export function children(): unknown {
   return (globalThis as any).document?.children;
 }
+export function childrenFrom(doc: any): unknown {
+  return (doc as any).children;
+}
+
 
 export function compatMode(): string | undefined {
   return (globalThis as any).document?.compatMode;
 }
+export function compatModeFrom(doc: any): unknown {
+  return (doc as any).compatMode;
+}
+
 
 export function contentType(): string | undefined {
   return (globalThis as any).document?.contentType;
 }
+export function contentTypeFrom(doc: any): unknown {
+  return (doc as any).contentType;
+}
+
 
 export function currentScript(): unknown {
   return (globalThis as any).document?.currentScript;
 }
+export function currentScriptFrom(doc: any): unknown {
+  return (doc as any).currentScript;
+}
+
 
 export function doctype(): unknown {
   return (globalThis as any).document?.doctype;
 }
+export function doctypeFrom(doc: any): unknown {
+  return (doc as any).doctype;
+}
+
 
 export function documentElement(): unknown {
   return (globalThis as any).document?.documentElement;
 }
+export function documentElementFrom(doc: any): unknown {
+  return (doc as any).documentElement;
+}
+
 
 export function documentURI(): string | undefined {
   return (globalThis as any).document?.documentURI;
 }
+export function documentURIFrom(doc: any): unknown {
+  return (doc as any).documentURI;
+}
+
 
 export function embeds(): unknown {
   return (globalThis as any).document?.embeds;
 }
+export function embedsFrom(doc: any): unknown {
+  return (doc as any).embeds;
+}
+
 
 export function featurePolicy(): unknown {
   return (globalThis as any).document?.featurePolicy;
 }
+export function featurePolicyFrom(doc: any): unknown {
+  return (doc as any).featurePolicy;
+}
+
 
 export function firstElementChild(): unknown {
   return (globalThis as any).document?.firstElementChild;
 }
+export function firstElementChildFrom(doc: any): unknown {
+  return (doc as any).firstElementChild;
+}
+
 
 export function fonts(): unknown {
   return (globalThis as any).document?.fonts;
 }
+export function fontsFrom(doc: any): unknown {
+  return (doc as any).fonts;
+}
+
 
 export function forms(): unknown {
   return (globalThis as any).document?.forms;
 }
+export function formsFrom(doc: any): unknown {
+  return (doc as any).forms;
+}
+
 
 export function fragmentDirective(): unknown {
   return (globalThis as any).document?.fragmentDirective;
 }
+export function fragmentDirectiveFrom(doc: any): unknown {
+  return (doc as any).fragmentDirective;
+}
+
 
 export function fullscreenElement(): unknown {
   return (globalThis as any).document?.fullscreenElement;
 }
+export function fullscreenElementFrom(doc: any): unknown {
+  return (doc as any).fullscreenElement;
+}
+
 
 export function head(): unknown {
   return (globalThis as any).document?.head;
 }
+export function headFrom(doc: any): unknown {
+  return (doc as any).head;
+}
+
 
 export function hidden(): boolean | undefined {
   return (globalThis as any).document?.hidden;
 }
+export function hiddenFrom(doc: any): unknown {
+  return (doc as any).hidden;
+}
+
 
 export function images(): unknown {
   return (globalThis as any).document?.images;
 }
+export function imagesFrom(doc: any): unknown {
+  return (doc as any).images;
+}
+
 
 export function implementation(): unknown {
   return (globalThis as any).document?.implementation;
 }
+export function implementationFrom(doc: any): unknown {
+  return (doc as any).implementation;
+}
+
 
 export function lastElementChild(): unknown {
   return (globalThis as any).document?.lastElementChild;
 }
+export function lastElementChildFrom(doc: any): unknown {
+  return (doc as any).lastElementChild;
+}
+
 
 export function links(): unknown {
   return (globalThis as any).document?.links;
 }
+export function linksFrom(doc: any): unknown {
+  return (doc as any).links;
+}
+
 
 export function pictureInPictureElement(): unknown {
   return (globalThis as any).document?.pictureInPictureElement;
 }
+export function pictureInPictureElementFrom(doc: any): unknown {
+  return (doc as any).pictureInPictureElement;
+}
+
 
 export function pictureInPictureEnabled(): boolean | undefined {
   return (globalThis as any).document?.pictureInPictureEnabled;
 }
+export function pictureInPictureEnabledFrom(doc: any): unknown {
+  return (doc as any).pictureInPictureEnabled;
+}
+
 
 export function plugins(): unknown {
   return (globalThis as any).document?.plugins;
 }
+export function pluginsFrom(doc: any): unknown {
+  return (doc as any).plugins;
+}
+
 
 export function pointerLockElement(): unknown {
   return (globalThis as any).document?.pointerLockElement;
 }
+export function pointerLockElementFrom(doc: any): unknown {
+  return (doc as any).pointerLockElement;
+}
+
 
 export function prerendering(): boolean | undefined {
   return (globalThis as any).document?.prerendering;
 }
+export function prerenderingFrom(doc: any): unknown {
+  return (doc as any).prerendering;
+}
+
 
 export function scripts(): unknown {
   return (globalThis as any).document?.scripts;
 }
+export function scriptsFrom(doc: any): unknown {
+  return (doc as any).scripts;
+}
+
 
 export function scrollingElement(): unknown {
   return (globalThis as any).document?.scrollingElement;
 }
+export function scrollingElementFrom(doc: any): unknown {
+  return (doc as any).scrollingElement;
+}
+
 
 export function styleSheets(): unknown {
   return (globalThis as any).document?.styleSheets;
 }
+export function styleSheetsFrom(doc: any): unknown {
+  return (doc as any).styleSheets;
+}
+
 
 export function timeline(): unknown {
   return (globalThis as any).document?.timeline;
 }
+export function timelineFrom(doc: any): unknown {
+  return (doc as any).timeline;
+}
+
 
 export function visibilityState(): unknown {
   return (globalThis as any).document?.visibilityState;
 }
+export function visibilityStateFrom(doc: any): unknown {
+  return (doc as any).visibilityState;
+}
+
 
 export function cookie(): string | undefined {
   return (globalThis as any).document?.cookie;
 }
+export function cookieFrom(doc: any): unknown {
+  return (doc as any).cookie;
+}
+
 
 export function defaultView(): unknown {
   return (globalThis as any).document?.defaultView;
 }
+export function defaultViewFrom(doc: any): unknown {
+  return (doc as any).defaultView;
+}
+
 
 export function designMode(): string | undefined {
   return (globalThis as any).document?.designMode;
 }
+export function designModeFrom(doc: any): unknown {
+  return (doc as any).designMode;
+}
+
 
 export function dir(): string | undefined {
   return (globalThis as any).document?.dir;
 }
+export function dirFrom(doc: any): unknown {
+  return (doc as any).dir;
+}
+
 
 export function fullscreenEnabled(): boolean | undefined {
   return (globalThis as any).document?.fullscreenEnabled;
 }
+export function fullscreenEnabledFrom(doc: any): unknown {
+  return (doc as any).fullscreenEnabled;
+}
+
 
 export function lastModified(): string | undefined {
   return (globalThis as any).document?.lastModified;
 }
+export function lastModifiedFrom(doc: any): unknown {
+  return (doc as any).lastModified;
+}
+
 
 export function location(): unknown {
   return (globalThis as any).document?.location;
 }
+export function locationFrom(doc: any): unknown {
+  return (doc as any).location;
+}
+
 
 export function readyState(): string | undefined {
   return (globalThis as any).document?.readyState;
 }
+export function readyStateFrom(doc: any): unknown {
+  return (doc as any).readyState;
+}
+
 
 export function referrer(): string | undefined {
   return (globalThis as any).document?.referrer;
 }
+export function referrerFrom(doc: any): unknown {
+  return (doc as any).referrer;
+}
+
 
 export function title(): string | undefined {
   return (globalThis as any).document?.title;
 }
+export function titleFrom(doc: any): unknown {
+  return (doc as any).title;
+}
+
 
 export function URL(): string | undefined {
   return (globalThis as any).document?.URL;
+}
+export function URLFrom(doc: any): unknown {
+  return (doc as any).URL;
 }

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1,247 +1,494 @@
 export function caches(): unknown {
   return (globalThis as any).caches;
 }
+export function cachesFrom(win: any): unknown {
+  return (win as any).caches;
+}
+
 
 export function clientInformation(): unknown {
   return (globalThis as any).clientInformation;
 }
+export function clientInformationFrom(win: any): unknown {
+  return (win as any).clientInformation;
+}
+
 
 export function closed(): boolean {
   return (globalThis as any).closed;
 }
+export function closedFrom(win: any): unknown {
+  return (win as any).closed;
+}
+
 
 export function cookieStore(): unknown {
   return (globalThis as any).cookieStore;
 }
+export function cookieStoreFrom(win: any): unknown {
+  return (win as any).cookieStore;
+}
+
 
 export function credentialless(): boolean {
   return (globalThis as any).credentialless;
 }
+export function credentiallessFrom(win: any): unknown {
+  return (win as any).credentialless;
+}
+
 
 export function crossOriginIsolated(): boolean {
   return (globalThis as any).crossOriginIsolated;
 }
+export function crossOriginIsolatedFrom(win: any): unknown {
+  return (win as any).crossOriginIsolated;
+}
+
 
 export function crypto(): unknown {
   return (globalThis as any).crypto;
 }
+export function cryptoFrom(win: any): unknown {
+  return (win as any).crypto;
+}
+
 
 export function customElements(): unknown {
   return (globalThis as any).customElements;
 }
+export function customElementsFrom(win: any): unknown {
+  return (win as any).customElements;
+}
+
 
 export function devicePixelRatio(): number {
   return (globalThis as any).devicePixelRatio;
 }
+export function devicePixelRatioFrom(win: any): unknown {
+  return (win as any).devicePixelRatio;
+}
+
 
 export function document(): unknown {
   return (globalThis as any).document;
 }
+export function documentFrom(win: any): unknown {
+  return (win as any).document;
+}
+
 
 export function documentPictureInPicture(): unknown {
   return (globalThis as any).documentPictureInPicture;
 }
+export function documentPictureInPictureFrom(win: any): unknown {
+  return (win as any).documentPictureInPicture;
+}
+
 
 export function fence(): unknown {
   return (globalThis as any).fence;
 }
+export function fenceFrom(win: any): unknown {
+  return (win as any).fence;
+}
+
 
 export function frameElement(): unknown {
   return (globalThis as any).frameElement;
 }
+export function frameElementFrom(win: any): unknown {
+  return (win as any).frameElement;
+}
+
 
 export function frames(): unknown {
   return (globalThis as any).frames;
 }
+export function framesFrom(win: any): unknown {
+  return (win as any).frames;
+}
+
 
 export function fullScreen(): boolean {
   return (globalThis as any).fullScreen;
 }
+export function fullScreenFrom(win: any): unknown {
+  return (win as any).fullScreen;
+}
+
 
 export function history(): unknown {
   return (globalThis as any).history;
 }
+export function historyFrom(win: any): unknown {
+  return (win as any).history;
+}
+
 
 export function indexedDb(): unknown {
   return (globalThis as any).indexedDB;
 }
+export function indexedDbFrom(win: any): unknown {
+  return (win as any).indexedDB;
+}
+
 
 export function innerHeight(): number {
   return (globalThis as any).innerHeight;
 }
+export function innerHeightFrom(win: any): unknown {
+  return (win as any).innerHeight;
+}
+
 
 export function innerWidth(): number {
   return (globalThis as any).innerWidth;
 }
+export function innerWidthFrom(win: any): unknown {
+  return (win as any).innerWidth;
+}
+
 
 export function isSecureContext(): boolean {
   return (globalThis as any).isSecureContext;
 }
+export function isSecureContextFrom(win: any): unknown {
+  return (win as any).isSecureContext;
+}
+
 
 export function launchQueue(): unknown {
   return (globalThis as any).launchQueue;
 }
+export function launchQueueFrom(win: any): unknown {
+  return (win as any).launchQueue;
+}
+
 
 export function length(): number {
   return (globalThis as any).length;
 }
+export function lengthFrom(win: any): unknown {
+  return (win as any).length;
+}
+
 
 export function localStorage(): unknown {
   return (globalThis as any).localStorage;
 }
+export function localStorageFrom(win: any): unknown {
+  return (win as any).localStorage;
+}
+
 
 export function location(): unknown {
   return (globalThis as any).location;
 }
+export function locationFrom(win: any): unknown {
+  return (win as any).location;
+}
+
 
 export function locationbar(): unknown {
   return (globalThis as any).locationbar;
 }
+export function locationbarFrom(win: any): unknown {
+  return (win as any).locationbar;
+}
+
 
 export function menubar(): unknown {
   return (globalThis as any).menubar;
 }
+export function menubarFrom(win: any): unknown {
+  return (win as any).menubar;
+}
+
 
 export function mozInnerScreenX(): number {
   return (globalThis as any).mozInnerScreenX;
 }
+export function mozInnerScreenXFrom(win: any): unknown {
+  return (win as any).mozInnerScreenX;
+}
+
 
 export function mozInnerScreenY(): number {
   return (globalThis as any).mozInnerScreenY;
 }
+export function mozInnerScreenYFrom(win: any): unknown {
+  return (win as any).mozInnerScreenY;
+}
+
 
 export function name(): string {
   return (globalThis as any).name;
 }
+export function nameFrom(win: any): unknown {
+  return (win as any).name;
+}
+
 
 export function navigation(): unknown {
   return (globalThis as any).navigation;
 }
+export function navigationFrom(win: any): unknown {
+  return (win as any).navigation;
+}
+
 
 export function navigator(): unknown {
   return (globalThis as any).navigator;
 }
+export function navigatorFrom(win: any): unknown {
+  return (win as any).navigator;
+}
+
 
 export function opener(): unknown {
   return (globalThis as any).opener;
 }
+export function openerFrom(win: any): unknown {
+  return (win as any).opener;
+}
+
 
 export function origin(): string {
   return (globalThis as any).origin;
 }
+export function originFrom(win: any): unknown {
+  return (win as any).origin;
+}
+
 
 export function originAgentCluster(): unknown {
   return (globalThis as any).originAgentCluster;
 }
+export function originAgentClusterFrom(win: any): unknown {
+  return (win as any).originAgentCluster;
+}
+
 
 export function outerHeight(): number {
   return (globalThis as any).outerHeight;
 }
+export function outerHeightFrom(win: any): unknown {
+  return (win as any).outerHeight;
+}
+
 
 export function outerWidth(): number {
   return (globalThis as any).outerWidth;
 }
+export function outerWidthFrom(win: any): unknown {
+  return (win as any).outerWidth;
+}
+
 
 export function pageXOffset(): number {
   return (globalThis as any).pageXOffset;
 }
+export function pageXOffsetFrom(win: any): unknown {
+  return (win as any).pageXOffset;
+}
+
 
 export function pageYOffset(): number {
   return (globalThis as any).pageYOffset;
 }
+export function pageYOffsetFrom(win: any): unknown {
+  return (win as any).pageYOffset;
+}
+
 
 export function parent(): unknown {
   return (globalThis as any).parent;
 }
+export function parentFrom(win: any): unknown {
+  return (win as any).parent;
+}
+
 
 export function performance(): unknown {
   return (globalThis as any).performance;
 }
+export function performanceFrom(win: any): unknown {
+  return (win as any).performance;
+}
+
 
 export function personalbar(): unknown {
   return (globalThis as any).personalbar;
 }
+export function personalbarFrom(win: any): unknown {
+  return (win as any).personalbar;
+}
+
 
 export function scheduler(): unknown {
   return (globalThis as any).scheduler;
 }
+export function schedulerFrom(win: any): unknown {
+  return (win as any).scheduler;
+}
+
 
 export function screen(): unknown {
   return (globalThis as any).screen;
 }
+export function screenFrom(win: any): unknown {
+  return (win as any).screen;
+}
+
 
 export function screenLeft(): number {
   return (globalThis as any).screenLeft;
 }
+export function screenLeftFrom(win: any): unknown {
+  return (win as any).screenLeft;
+}
+
 
 export function screenTop(): number {
   return (globalThis as any).screenTop;
 }
+export function screenTopFrom(win: any): unknown {
+  return (win as any).screenTop;
+}
+
 
 export function screenX(): number {
   return (globalThis as any).screenX;
 }
+export function screenXFrom(win: any): unknown {
+  return (win as any).screenX;
+}
+
 
 export function screenY(): number {
   return (globalThis as any).screenY;
 }
+export function screenYFrom(win: any): unknown {
+  return (win as any).screenY;
+}
+
 
 export function scrollMaxX(): number {
   return (globalThis as any).scrollMaxX;
 }
+export function scrollMaxXFrom(win: any): unknown {
+  return (win as any).scrollMaxX;
+}
+
 
 export function scrollMaxY(): number {
   return (globalThis as any).scrollMaxY;
 }
+export function scrollMaxYFrom(win: any): unknown {
+  return (win as any).scrollMaxY;
+}
+
 
 export function scrollX(): number {
   return (globalThis as any).scrollX;
 }
+export function scrollXFrom(win: any): unknown {
+  return (win as any).scrollX;
+}
+
 
 export function scrollY(): number {
   return (globalThis as any).scrollY;
 }
+export function scrollYFrom(win: any): unknown {
+  return (win as any).scrollY;
+}
+
 
 export function scrollbars(): unknown {
   return (globalThis as any).scrollbars;
 }
+export function scrollbarsFrom(win: any): unknown {
+  return (win as any).scrollbars;
+}
+
 
 export function self(): unknown {
   return (globalThis as any).self;
 }
+export function selfFrom(win: any): unknown {
+  return (win as any).self;
+}
+
 
 export function sessionStorage(): unknown {
   return (globalThis as any).sessionStorage;
 }
+export function sessionStorageFrom(win: any): unknown {
+  return (win as any).sessionStorage;
+}
+
 
 export function sharedStorage(): unknown {
   return (globalThis as any).sharedStorage;
 }
+export function sharedStorageFrom(win: any): unknown {
+  return (win as any).sharedStorage;
+}
+
 
 export function speechSynthesis(): unknown {
   return (globalThis as any).speechSynthesis;
 }
+export function speechSynthesisFrom(win: any): unknown {
+  return (win as any).speechSynthesis;
+}
+
 
 export function statusbar(): unknown {
   return (globalThis as any).statusbar;
 }
+export function statusbarFrom(win: any): unknown {
+  return (win as any).statusbar;
+}
+
 
 export function toolbar(): unknown {
   return (globalThis as any).toolbar;
 }
+export function toolbarFrom(win: any): unknown {
+  return (win as any).toolbar;
+}
+
 
 export function top(): unknown {
   return (globalThis as any).top;
 }
+export function topFrom(win: any): unknown {
+  return (win as any).top;
+}
+
 
 export function trustedTypes(): unknown {
   return (globalThis as any).trustedTypes;
 }
+export function trustedTypesFrom(win: any): unknown {
+  return (win as any).trustedTypes;
+}
+
 
 export function visualViewport(): unknown {
   return (globalThis as any).visualViewport;
 }
+export function visualViewportFrom(win: any): unknown {
+  return (win as any).visualViewport;
+}
+
 
 export function window(): unknown {
   return (globalThis as any).window;
+}
+export function windowFrom(win: any): unknown {
+  return (win as any).window;
 }

--- a/tests/document/index.test.ts
+++ b/tests/document/index.test.ts
@@ -47,6 +47,7 @@ import {
   title,
   URL,
 } from "../../src/document";
+import * as documentModule from "../../src/document";
 import { expect, test } from "bun:test";
 
 test("Document returns global Document", () => {
@@ -284,3 +285,17 @@ test("URL returns document.URL", () => {
   (globalThis as any).document = { URL: "http://url" };
   expect(URL()).toBe("http://url");
 });
+
+// New tests for instance-specific document functions
+const documentInstance: any = {};
+Object.keys(documentModule)
+  .filter((k) => k.endsWith("From"))
+  .forEach((fnName, idx) => {
+    const prop = fnName.slice(0, -4);
+    documentInstance[prop] = `doc_${idx}`;
+    test(`${fnName} returns ${prop} from passed document`, () => {
+      expect((documentModule as any)[fnName](documentInstance)).toEqual(
+        documentInstance[prop]
+      );
+    });
+  });

--- a/tests/window/index.test.ts
+++ b/tests/window/index.test.ts
@@ -62,6 +62,7 @@ import {
   visualViewport,
   window,
 } from "../../src/window";
+import * as windowModule from "../../src/window";
 import { expect, test } from "bun:test";
 
 test("caches returns global caches", () => {
@@ -373,3 +374,18 @@ test("window returns global window", () => {
   (globalThis as any).window = { w: 1 };
   expect(window()).toEqual({ w: 1 });
 });
+
+// New tests for instance-specific functions
+const windowInstance: any = {};
+Object.keys(windowModule)
+  .filter((k) => k.endsWith("From"))
+  .forEach((fnName, idx) => {
+    const prop = fnName.slice(0, -4);
+    const propName = prop === "indexedDb" ? "indexedDB" : prop;
+    windowInstance[propName] = `val_${idx}`;
+    test(`${fnName} returns ${propName} from passed window`, () => {
+      expect((windowModule as any)[fnName](windowInstance)).toEqual(
+        windowInstance[propName]
+      );
+    });
+  });


### PR DESCRIPTION
## Summary
- add `From` versions of all window and document APIs for instance-specific access
- test new helpers and preserve existing global checks

## Testing
- `bun test`