### PR TITLE
Add wrappers for more DOM APIs

### DIFF
--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -123,6 +123,55 @@ export function createEventFrom(doc: any, ...args: any[]): unknown {
 }
 
 
+export function createNodeIterator(...args: any[]): unknown {
+  return (globalThis as any).document?.createNodeIterator(...args);
+}
+export function createNodeIteratorFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).createNodeIterator(...args);
+}
+
+export function createProcessingInstruction(...args: any[]): unknown {
+  return (globalThis as any).document?.createProcessingInstruction(...args);
+}
+export function createProcessingInstructionFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).createProcessingInstruction(...args);
+}
+
+export function createRange(...args: any[]): unknown {
+  return (globalThis as any).document?.createRange(...args);
+}
+export function createRangeFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).createRange(...args);
+}
+
+export function createTextNode(...args: any[]): unknown {
+  return (globalThis as any).document?.createTextNode(...args);
+}
+export function createTextNodeFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).createTextNode(...args);
+}
+
+export function createTouch(...args: any[]): unknown {
+  return (globalThis as any).document?.createTouch(...args);
+}
+export function createTouchFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).createTouch(...args);
+}
+
+export function createTouchList(...args: any[]): unknown {
+  return (globalThis as any).document?.createTouchList(...args);
+}
+export function createTouchListFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).createTouchList(...args);
+}
+
+export function createTreeWalker(...args: any[]): unknown {
+  return (globalThis as any).document?.createTreeWalker(...args);
+}
+export function createTreeWalkerFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).createTreeWalker(...args);
+}
+
 export function body(): unknown {
   return (globalThis as any).document?.body;
 }
@@ -208,6 +257,47 @@ export function embeds(): unknown {
 }
 export function embedsFrom(doc: any): unknown {
   return (doc as any).embeds;
+}
+export function elementFromPoint(...args: any[]): unknown {
+  return (globalThis as any).document?.elementFromPoint(...args);
+}
+export function elementFromPointFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).elementFromPoint(...args);
+}
+
+export function elementsFromPoint(...args: any[]): unknown {
+  return (globalThis as any).document?.elementsFromPoint(...args);
+}
+export function elementsFromPointFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).elementsFromPoint(...args);
+}
+
+export function enableStyleSheetsForSet(...args: any[]): unknown {
+  return (globalThis as any).document?.enableStyleSheetsForSet(...args);
+}
+export function enableStyleSheetsForSetFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).enableStyleSheetsForSet(...args);
+}
+
+export function exitFullscreen(...args: any[]): unknown {
+  return (globalThis as any).document?.exitFullscreen(...args);
+}
+export function exitFullscreenFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).exitFullscreen(...args);
+}
+
+export function exitPictureInPicture(...args: any[]): unknown {
+  return (globalThis as any).document?.exitPictureInPicture(...args);
+}
+export function exitPictureInPictureFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).exitPictureInPicture(...args);
+}
+
+export function exitPointerLock(...args: any[]): unknown {
+  return (globalThis as any).document?.exitPointerLock(...args);
+}
+export function exitPointerLockFrom(doc: any, ...args: any[]): unknown {
+  return (doc as any).exitPointerLock(...args);
 }
 
 

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -174,6 +174,14 @@ export function documentPictureInPictureFrom(win: any): unknown {
 }
 
 
+export function dump(...args: any[]): unknown {
+  return (globalThis as any).dump(...args);
+}
+export function dumpFrom(win: any, ...args: any[]): unknown {
+  return (win as any).dump(...args);
+}
+
+
 export function fence(): unknown {
   return (globalThis as any).fence;
 }
@@ -181,6 +189,34 @@ export function fenceFrom(win: any): unknown {
   return (win as any).fence;
 }
 
+
+export function fetch(...args: any[]): unknown {
+  return (globalThis as any).fetch(...args);
+}
+export function fetchFrom(win: any, ...args: any[]): unknown {
+  return (win as any).fetch(...args);
+}
+
+export function fetchLater(...args: any[]): unknown {
+  return (globalThis as any).fetchLater(...args);
+}
+export function fetchLaterFrom(win: any, ...args: any[]): unknown {
+  return (win as any).fetchLater(...args);
+}
+
+export function find(...args: any[]): unknown {
+  return (globalThis as any).find(...args);
+}
+export function findFrom(win: any, ...args: any[]): unknown {
+  return (win as any).find(...args);
+}
+
+export function focus(...args: any[]): unknown {
+  return (globalThis as any).focus(...args);
+}
+export function focusFrom(win: any, ...args: any[]): unknown {
+  return (win as any).focus(...args);
+}
 
 export function frameElement(): unknown {
   return (globalThis as any).frameElement;
@@ -205,6 +241,34 @@ export function fullScreenFrom(win: any): unknown {
   return (win as any).fullScreen;
 }
 
+
+export function getComputedStyle(...args: any[]): unknown {
+  return (globalThis as any).getComputedStyle(...args);
+}
+export function getComputedStyleFrom(win: any, ...args: any[]): unknown {
+  return (win as any).getComputedStyle(...args);
+}
+
+export function getDefaultComputedStyle(...args: any[]): unknown {
+  return (globalThis as any).getDefaultComputedStyle(...args);
+}
+export function getDefaultComputedStyleFrom(win: any, ...args: any[]): unknown {
+  return (win as any).getDefaultComputedStyle(...args);
+}
+
+export function getScreenDetails(...args: any[]): unknown {
+  return (globalThis as any).getScreenDetails(...args);
+}
+export function getScreenDetailsFrom(win: any, ...args: any[]): unknown {
+  return (win as any).getScreenDetails(...args);
+}
+
+export function getSelection(...args: any[]): unknown {
+  return (globalThis as any).getSelection(...args);
+}
+export function getSelectionFrom(win: any, ...args: any[]): unknown {
+  return (win as any).getSelection(...args);
+}
 
 export function history(): unknown {
   return (globalThis as any).history;
@@ -286,6 +350,13 @@ export function locationbarFrom(win: any): unknown {
 }
 
 
+export function matchMedia(...args: any[]): unknown {
+  return (globalThis as any).matchMedia(...args);
+}
+export function matchMediaFrom(win: any, ...args: any[]): unknown {
+  return (win as any).matchMedia(...args);
+}
+
 export function menubar(): unknown {
   return (globalThis as any).menubar;
 }
@@ -310,6 +381,20 @@ export function mozInnerScreenYFrom(win: any): unknown {
 }
 
 
+export function moveBy(...args: any[]): unknown {
+  return (globalThis as any).moveBy(...args);
+}
+export function moveByFrom(win: any, ...args: any[]): unknown {
+  return (win as any).moveBy(...args);
+}
+
+export function moveTo(...args: any[]): unknown {
+  return (globalThis as any).moveTo(...args);
+}
+export function moveToFrom(win: any, ...args: any[]): unknown {
+  return (win as any).moveTo(...args);
+}
+
 export function name(): string {
   return (globalThis as any).name;
 }
@@ -333,6 +418,13 @@ export function navigatorFrom(win: any): unknown {
   return (win as any).navigator;
 }
 
+
+export function open(...args: any[]): unknown {
+  return (globalThis as any).open(...args);
+}
+export function openFrom(win: any, ...args: any[]): unknown {
+  return (win as any).open(...args);
+}
 
 export function opener(): unknown {
   return (globalThis as any).opener;
@@ -413,6 +505,55 @@ export function personalbarFrom(win: any): unknown {
   return (win as any).personalbar;
 }
 
+
+export function postMessage(...args: any[]): unknown {
+  return (globalThis as any).postMessage(...args);
+}
+export function postMessageFrom(win: any, ...args: any[]): unknown {
+  return (win as any).postMessage(...args);
+}
+
+export function print(...args: any[]): unknown {
+  return (globalThis as any).print(...args);
+}
+export function printFrom(win: any, ...args: any[]): unknown {
+  return (win as any).print(...args);
+}
+
+export function prompt(...args: any[]): unknown {
+  return (globalThis as any).prompt(...args);
+}
+export function promptFrom(win: any, ...args: any[]): unknown {
+  return (win as any).prompt(...args);
+}
+
+export function queryLocalFonts(...args: any[]): unknown {
+  return (globalThis as any).queryLocalFonts(...args);
+}
+export function queryLocalFontsFrom(win: any, ...args: any[]): unknown {
+  return (win as any).queryLocalFonts(...args);
+}
+
+export function queueMicrotask(...args: any[]): unknown {
+  return (globalThis as any).queueMicrotask(...args);
+}
+export function queueMicrotaskFrom(win: any, ...args: any[]): unknown {
+  return (win as any).queueMicrotask(...args);
+}
+
+export function reportError(...args: any[]): unknown {
+  return (globalThis as any).reportError(...args);
+}
+export function reportErrorFrom(win: any, ...args: any[]): unknown {
+  return (win as any).reportError(...args);
+}
+
+export function requestAnimationFrame(...args: any[]): unknown {
+  return (globalThis as any).requestAnimationFrame(...args);
+}
+export function requestAnimationFrameFrom(win: any, ...args: any[]): unknown {
+  return (win as any).requestAnimationFrame(...args);
+}
 
 export function scheduler(): unknown {
   return (globalThis as any).scheduler;

--- a/tests/document/index.test.ts
+++ b/tests/document/index.test.ts
@@ -15,6 +15,13 @@ import {
   createElement,
   createElementNS,
   createEvent,
+  createNodeIterator,
+  createProcessingInstruction,
+  createRange,
+  createTextNode,
+  createTouch,
+  createTouchList,
+  createTreeWalker,
   body,
   characterSet,
   childElementCount,
@@ -26,6 +33,12 @@ import {
   documentElement,
   documentURI,
   embeds,
+  elementFromPoint,
+  elementsFromPoint,
+  enableStyleSheetsForSet,
+  exitFullscreen,
+  exitPictureInPicture,
+  exitPointerLock,
   featurePolicy,
   firstElementChild,
   fonts,
@@ -200,6 +213,69 @@ test("createEventFrom calls createEvent on passed document", () => {
   expect(documentModule.createEventFrom(doc, "evt")).toBe("evt");
 });
 
+test("createNodeIterator calls document.createNodeIterator", () => {
+  (globalThis as any).document = { createNodeIterator: (n: any) => ({ n }) };
+  expect(createNodeIterator("n")).toEqual({ n: "n" });
+});
+test("createNodeIteratorFrom calls createNodeIterator on passed document", () => {
+  const doc: any = { createNodeIterator: (n: any) => n + "F" };
+  expect(documentModule.createNodeIteratorFrom(doc, "x")).toBe("xF");
+});
+
+test("createProcessingInstruction calls document.createProcessingInstruction", () => {
+  (globalThis as any).document = { createProcessingInstruction: (t: any, d: any) => `${t}:${d}` };
+  expect(createProcessingInstruction("t","d")).toBe("t:d");
+});
+test("createProcessingInstructionFrom calls createProcessingInstruction on passed document", () => {
+  const doc: any = { createProcessingInstruction: () => "pi" };
+  expect(documentModule.createProcessingInstructionFrom(doc, "a","b")).toBe("pi");
+});
+
+test("createRange calls document.createRange", () => {
+  (globalThis as any).document = { createRange: () => "R" };
+  expect(createRange()).toBe("R");
+});
+test("createRangeFrom calls createRange on passed document", () => {
+  const doc: any = { createRange: () => "DR" };
+  expect(documentModule.createRangeFrom(doc)).toBe("DR");
+});
+
+test("createTextNode calls document.createTextNode", () => {
+  (globalThis as any).document = { createTextNode: (t: any) => t + t };
+  expect(createTextNode("a")).toBe("aa");
+});
+test("createTextNodeFrom calls createTextNode on passed document", () => {
+  const doc: any = { createTextNode: (t: any) => t.toUpperCase() };
+  expect(documentModule.createTextNodeFrom(doc, "b")).toBe("B");
+});
+
+test("createTouch calls document.createTouch", () => {
+  (globalThis as any).document = { createTouch: (v: any) => ({ v }) };
+  expect(createTouch(1)).toEqual({ v: 1 });
+});
+test("createTouchFrom calls createTouch on passed document", () => {
+  const doc: any = { createTouch: (v: any) => ({ dv: v }) };
+  expect(documentModule.createTouchFrom(doc, 2)).toEqual({ dv: 2 });
+});
+
+test("createTouchList calls document.createTouchList", () => {
+  (globalThis as any).document = { createTouchList: (...a: any[]) => a.length };
+  expect(createTouchList(1,2)).toBe(2);
+});
+test("createTouchListFrom calls createTouchList on passed document", () => {
+  const doc: any = { createTouchList: () => 5 };
+  expect(documentModule.createTouchListFrom(doc)).toBe(5);
+});
+
+test("createTreeWalker calls document.createTreeWalker", () => {
+  (globalThis as any).document = { createTreeWalker: (n: any) => ({ node: n }) };
+  expect(createTreeWalker("n")).toEqual({ node: "n" });
+});
+test("createTreeWalkerFrom calls createTreeWalker on passed document", () => {
+  const doc: any = { createTreeWalker: () => "tw" };
+  expect(documentModule.createTreeWalkerFrom(doc, 0)).toBe("tw");
+});
+
 test("body returns document.body", () => {
   (globalThis as any).document = { body: "b" };
   expect(body()).toBe("b");
@@ -253,6 +329,60 @@ test("documentURI returns document.documentURI", () => {
 test("embeds returns document.embeds", () => {
   (globalThis as any).document = { embeds: [1, 2] };
   expect(embeds()).toEqual([1, 2]);
+});
+
+test("elementFromPoint calls document.elementFromPoint", () => {
+  (globalThis as any).document = { elementFromPoint: (x: any, y: any) => `${x}-${y}` };
+  expect(elementFromPoint(1,2)).toBe("1-2");
+});
+test("elementFromPointFrom calls elementFromPoint on passed document", () => {
+  const doc: any = { elementFromPoint: () => "el" };
+  expect(documentModule.elementFromPointFrom(doc, 0,0)).toBe("el");
+});
+
+test("elementsFromPoint calls document.elementsFromPoint", () => {
+  (globalThis as any).document = { elementsFromPoint: () => ["a"] };
+  expect(elementsFromPoint()).toEqual(["a"]);
+});
+test("elementsFromPointFrom calls elementsFromPoint on passed document", () => {
+  const doc: any = { elementsFromPoint: () => ["b"] };
+  expect(documentModule.elementsFromPointFrom(doc)).toEqual(["b"]);
+});
+
+test("enableStyleSheetsForSet calls document.enableStyleSheetsForSet", () => {
+  (globalThis as any).document = { enableStyleSheetsForSet: (s: any) => s };
+  expect(enableStyleSheetsForSet("set")).toBe("set");
+});
+test("enableStyleSheetsForSetFrom calls enableStyleSheetsForSet on passed document", () => {
+  const doc: any = { enableStyleSheetsForSet: (s: any) => `d:${s}` };
+  expect(documentModule.enableStyleSheetsForSetFrom(doc, "s")).toBe("d:s");
+});
+
+test("exitFullscreen calls document.exitFullscreen", () => {
+  (globalThis as any).document = { exitFullscreen: () => "ef" };
+  expect(exitFullscreen()).toBe("ef");
+});
+test("exitFullscreenFrom calls exitFullscreen on passed document", () => {
+  const doc: any = { exitFullscreen: () => "wf" };
+  expect(documentModule.exitFullscreenFrom(doc)).toBe("wf");
+});
+
+test("exitPictureInPicture calls document.exitPictureInPicture", () => {
+  (globalThis as any).document = { exitPictureInPicture: () => 1 };
+  expect(exitPictureInPicture()).toBe(1);
+});
+test("exitPictureInPictureFrom calls exitPictureInPicture on passed document", () => {
+  const doc: any = { exitPictureInPicture: () => 2 };
+  expect(documentModule.exitPictureInPictureFrom(doc)).toBe(2);
+});
+
+test("exitPointerLock calls document.exitPointerLock", () => {
+  (globalThis as any).document = { exitPointerLock: () => "pl" };
+  expect(exitPointerLock()).toBe("pl");
+});
+test("exitPointerLockFrom calls exitPointerLock on passed document", () => {
+  const doc: any = { exitPointerLock: () => "dpl" };
+  expect(documentModule.exitPointerLockFrom(doc)).toBe("dpl");
 });
 
 test("featurePolicy returns document.featurePolicy", () => {
@@ -436,6 +566,19 @@ const skipDocumentFromFns = [
   "createElementFrom",
   "createElementNSFrom",
   "createEventFrom",
+  "createNodeIteratorFrom",
+  "createProcessingInstructionFrom",
+  "createRangeFrom",
+  "createTextNodeFrom",
+  "createTouchFrom",
+  "createTouchListFrom",
+  "createTreeWalkerFrom",
+  "elementFromPointFrom",
+  "elementsFromPointFrom",
+  "enableStyleSheetsForSetFrom",
+  "exitFullscreenFrom",
+  "exitPictureInPictureFrom",
+  "exitPointerLockFrom",
 ];
 Object.keys(documentModule)
   .filter((k) => k.endsWith("From") && !skipDocumentFromFns.includes(k))

--- a/tests/window/index.test.ts
+++ b/tests/window/index.test.ts
@@ -21,10 +21,19 @@ import {
   devicePixelRatio,
   document,
   documentPictureInPicture,
+  dump,
   fence,
+  fetch,
+  fetchLater,
+  find,
+  focus,
   frameElement,
   frames,
   fullScreen,
+  getComputedStyle,
+  getDefaultComputedStyle,
+  getScreenDetails,
+  getSelection,
   history,
   indexedDb,
   innerHeight,
@@ -35,12 +44,16 @@ import {
   localStorage,
   location,
   locationbar,
+  matchMedia,
   menubar,
   mozInnerScreenX,
   mozInnerScreenY,
+  moveBy,
+  moveTo,
   name,
   navigation,
   navigator,
+  open,
   opener,
   origin,
   originAgentCluster,
@@ -51,6 +64,13 @@ import {
   parent,
   performance,
   personalbar,
+  postMessage,
+  print,
+  prompt,
+  queryLocalFonts,
+  queueMicrotask,
+  reportError,
+  requestAnimationFrame,
   scheduler,
   screen,
   screenLeft,
@@ -230,6 +250,51 @@ test("documentPictureInPicture returns global documentPictureInPicture", () => {
   expect(documentPictureInPicture()).toEqual({ pip: true });
 });
 
+test("dump calls global dump", () => {
+  (globalThis as any).dump = (...a: any[]) => a.join("|");
+  expect(dump("a", "b")).toBe("a|b");
+});
+test("dumpFrom calls dump on passed window", () => {
+  const win: any = { dump: (...a: any[]) => a.length };
+  expect(windowModule.dumpFrom(win, 1, 2, 3)).toBe(3);
+});
+
+test("fetch calls global fetch", () => {
+  (globalThis as any).fetch = (u: any) => `F:${u}`;
+  expect(fetch("url")).toBe("F:url");
+});
+test("fetchFrom calls fetch on passed window", () => {
+  const win: any = { fetch: (u: any) => `WF:${u}` };
+  expect(windowModule.fetchFrom(win, "u")).toBe("WF:u");
+});
+
+test("fetchLater calls global fetchLater", () => {
+  (globalThis as any).fetchLater = (u: any) => `FL:${u}`;
+  expect(fetchLater("u")).toBe("FL:u");
+});
+test("fetchLaterFrom calls fetchLater on passed window", () => {
+  const win: any = { fetchLater: (u: any) => `WFL:${u}` };
+  expect(windowModule.fetchLaterFrom(win, "x")).toBe("WFL:x");
+});
+
+test("find calls global find", () => {
+  (globalThis as any).find = (t: any) => t.toUpperCase();
+  expect(find("x")).toBe("X");
+});
+test("findFrom calls find on passed window", () => {
+  const win: any = { find: (s: any) => s + s };
+  expect(windowModule.findFrom(win, "a")).toBe("aa");
+});
+
+test("focus calls global focus", () => {
+  (globalThis as any).focus = () => "FOCUS";
+  expect(focus()).toBe("FOCUS");
+});
+test("focusFrom calls focus on passed window", () => {
+  const win: any = { focus: () => "WF" };
+  expect(windowModule.focusFrom(win)).toBe("WF");
+});
+
 test("fence returns global fence", () => {
   (globalThis as any).fence = { fenced: true };
   expect(fence()).toEqual({ fenced: true });
@@ -248,6 +313,42 @@ test("frames returns global frames", () => {
 test("fullScreen returns global fullScreen", () => {
   (globalThis as any).fullScreen = true;
   expect(fullScreen()).toBe(true);
+});
+
+test("getComputedStyle calls global getComputedStyle", () => {
+  (globalThis as any).getComputedStyle = (e: any) => ({ el: e });
+  expect(getComputedStyle("div")).toEqual({ el: "div" });
+});
+test("getComputedStyleFrom calls getComputedStyle on passed window", () => {
+  const win: any = { getComputedStyle: (e: any) => ({ w: e }) };
+  expect(windowModule.getComputedStyleFrom(win, "p")).toEqual({ w: "p" });
+});
+
+test("getDefaultComputedStyle calls global getDefaultComputedStyle", () => {
+  (globalThis as any).getDefaultComputedStyle = (e: any) => ({ d: e });
+  expect(getDefaultComputedStyle("el")).toEqual({ d: "el" });
+});
+test("getDefaultComputedStyleFrom calls getDefaultComputedStyle on passed window", () => {
+  const win: any = { getDefaultComputedStyle: (e: any) => ({ win: e }) };
+  expect(windowModule.getDefaultComputedStyleFrom(win, "x")).toEqual({ win: "x" });
+});
+
+test("getScreenDetails calls global getScreenDetails", () => {
+  (globalThis as any).getScreenDetails = () => "scr";
+  expect(getScreenDetails()).toBe("scr");
+});
+test("getScreenDetailsFrom calls getScreenDetails on passed window", () => {
+  const win: any = { getScreenDetails: () => "ws" };
+  expect(windowModule.getScreenDetailsFrom(win)).toBe("ws");
+});
+
+test("getSelection calls global getSelection", () => {
+  (globalThis as any).getSelection = () => "sel";
+  expect(getSelection()).toBe("sel");
+});
+test("getSelectionFrom calls getSelection on passed window", () => {
+  const win: any = { getSelection: () => "wsel" };
+  expect(windowModule.getSelectionFrom(win)).toBe("wsel");
 });
 
 test("history returns global history", () => {
@@ -300,6 +401,15 @@ test("locationbar returns global locationbar", () => {
   expect(locationbar()).toEqual({ bar: true });
 });
 
+test("matchMedia calls global matchMedia", () => {
+  (globalThis as any).matchMedia = (q: any) => ({ q });
+  expect(matchMedia("m")).toEqual({ q: "m" });
+});
+test("matchMediaFrom calls matchMedia on passed window", () => {
+  const win: any = { matchMedia: (q: any) => ({ w: q }) };
+  expect(windowModule.matchMediaFrom(win, "mq")).toEqual({ w: "mq" });
+});
+
 test("menubar returns global menubar", () => {
   (globalThis as any).menubar = { menu: true };
   expect(menubar()).toEqual({ menu: true });
@@ -315,6 +425,24 @@ test("mozInnerScreenY returns global mozInnerScreenY", () => {
   expect(mozInnerScreenY()).toBe(2);
 });
 
+test("moveBy calls global moveBy", () => {
+  (globalThis as any).moveBy = (x: any, y: any) => x + y;
+  expect(moveBy(1, 2)).toBe(3);
+});
+test("moveByFrom calls moveBy on passed window", () => {
+  const win: any = { moveBy: (x: any, y: any) => x * y };
+  expect(windowModule.moveByFrom(win, 2, 3)).toBe(6);
+});
+
+test("moveTo calls global moveTo", () => {
+  (globalThis as any).moveTo = (x: any, y: any) => x - y;
+  expect(moveTo(5, 2)).toBe(3);
+});
+test("moveToFrom calls moveTo on passed window", () => {
+  const win: any = { moveTo: (x: any, y: any) => y - x };
+  expect(windowModule.moveToFrom(win, 1, 4)).toBe(3);
+});
+
 test("name returns global name", () => {
   (globalThis as any).name = "win";
   expect(name()).toBe("win");
@@ -328,6 +456,15 @@ test("navigation returns global navigation", () => {
 test("navigator returns global navigator", () => {
   (globalThis as any).navigator = { ua: "test" };
   expect(navigator()).toEqual({ ua: "test" });
+});
+
+test("open calls global open", () => {
+  (globalThis as any).open = (u: any) => `O:${u}`;
+  expect(open("a")).toBe("O:a");
+});
+test("openFrom calls open on passed window", () => {
+  const win: any = { open: (u: any) => `W:${u}` };
+  expect(windowModule.openFrom(win, "b")).toBe("W:b");
 });
 
 test("opener returns global opener", () => {
@@ -378,6 +515,77 @@ test("performance returns global performance", () => {
 test("personalbar returns global personalbar", () => {
   (globalThis as any).personalbar = { bar: 1 };
   expect(personalbar()).toEqual({ bar: 1 });
+});
+
+test("postMessage calls global postMessage", () => {
+  (globalThis as any).postMessage = (m: any) => `P:${m}`;
+  expect(postMessage("msg")).toBe("P:msg");
+});
+test("postMessageFrom calls postMessage on passed window", () => {
+  const win: any = { postMessage: (m: any) => `WP:${m}` };
+  expect(windowModule.postMessageFrom(win, "ms")).toBe("WP:ms");
+});
+
+test("print calls global print", () => {
+  (globalThis as any).print = () => "PRINT";
+  expect(print()).toBe("PRINT");
+});
+test("printFrom calls print on passed window", () => {
+  const win: any = { print: () => "WPRINT" };
+  expect(windowModule.printFrom(win)).toBe("WPRINT");
+});
+
+test("prompt calls global prompt", () => {
+  (globalThis as any).prompt = () => "PROMPT";
+  expect(prompt()).toBe("PROMPT");
+});
+test("promptFrom calls prompt on passed window", () => {
+  const win: any = { prompt: () => "WP" };
+  expect(windowModule.promptFrom(win)).toBe("WP");
+});
+
+test("queryLocalFonts calls global queryLocalFonts", () => {
+  (globalThis as any).queryLocalFonts = () => [1];
+  expect(queryLocalFonts()).toEqual([1]);
+});
+test("queryLocalFontsFrom calls queryLocalFonts on passed window", () => {
+  const win: any = { queryLocalFonts: () => [2] };
+  expect(windowModule.queryLocalFontsFrom(win)).toEqual([2]);
+});
+
+test("queueMicrotask calls global queueMicrotask", () => {
+  (globalThis as any).queueMicrotask = (cb: any) => cb("q");
+  let val = "";
+  queueMicrotask((v: any) => (val = v));
+  expect(val).toBe("q");
+});
+test("queueMicrotaskFrom calls queueMicrotask on passed window", () => {
+  const win: any = { queueMicrotask: (cb: any) => cb(5) };
+  let n = 0;
+  windowModule.queueMicrotaskFrom(win, (v: any) => (n = v));
+  expect(n).toBe(5);
+});
+
+test("reportError calls global reportError", () => {
+  (globalThis as any).reportError = (e: any) => `R:${e}`;
+  expect(reportError("err")).toBe("R:err");
+});
+test("reportErrorFrom calls reportError on passed window", () => {
+  const win: any = { reportError: (e: any) => `WR:${e}` };
+  expect(windowModule.reportErrorFrom(win, "e")).toBe("WR:e");
+});
+
+test("requestAnimationFrame calls global requestAnimationFrame", () => {
+  (globalThis as any).requestAnimationFrame = (cb: any) => cb(3);
+  let r = 0;
+  requestAnimationFrame((v: any) => (r = v));
+  expect(r).toBe(3);
+});
+test("requestAnimationFrameFrom calls requestAnimationFrame on passed window", () => {
+  const win: any = { requestAnimationFrame: (cb: any) => cb(7) };
+  let r = 0;
+  windowModule.requestAnimationFrameFrom(win, (v: any) => (r = v));
+  expect(r).toBe(7);
 });
 
 test("scheduler returns global scheduler", () => {
@@ -499,6 +707,26 @@ const skipWindowFromFns = [
   "closeFrom",
   "confirmFrom",
   "createImageBitmapFrom",
+  "dumpFrom",
+  "fetchFrom",
+  "fetchLaterFrom",
+  "findFrom",
+  "focusFrom",
+  "getComputedStyleFrom",
+  "getDefaultComputedStyleFrom",
+  "getScreenDetailsFrom",
+  "getSelectionFrom",
+  "matchMediaFrom",
+  "moveByFrom",
+  "moveToFrom",
+  "openFrom",
+  "postMessageFrom",
+  "printFrom",
+  "promptFrom",
+  "queryLocalFontsFrom",
+  "queueMicrotaskFrom",
+  "reportErrorFrom",
+  "requestAnimationFrameFrom",
 ];
 Object.keys(windowModule)
   .filter((k) => k.endsWith("From") && !skipWindowFromFns.includes(k))


### PR DESCRIPTION
## Summary
- implement wrappers for additional `window` and `document` methods
- extend regression tests for the new wrappers

## Testing
- `bun test`