### PR TITLE
Refactor tests to use namespace imports

### DIFF
--- a/tests/document/index.test.ts
+++ b/tests/document/index.test.ts
@@ -1,100 +1,25 @@
-import {
-  Document,
-  activeElement,
-  adoptedStyleSheets,
-  adoptNode,
-  append,
-  browsingTopics,
-  caretPositionFromPoint,
-  caretRangeFromPoint,
-  createAttribute,
-  createAttributeNS,
-  createCDATASection,
-  createComment,
-  createDocumentFragment,
-  createElement,
-  createElementNS,
-  createEvent,
-  createNodeIterator,
-  createProcessingInstruction,
-  createRange,
-  createTextNode,
-  createTouch,
-  createTouchList,
-  createTreeWalker,
-  body,
-  characterSet,
-  childElementCount,
-  children,
-  compatMode,
-  contentType,
-  currentScript,
-  doctype,
-  documentElement,
-  documentURI,
-  embeds,
-  elementFromPoint,
-  elementsFromPoint,
-  enableStyleSheetsForSet,
-  exitFullscreen,
-  exitPictureInPicture,
-  exitPointerLock,
-  featurePolicy,
-  firstElementChild,
-  fonts,
-  forms,
-  fragmentDirective,
-  fullscreenElement,
-  head,
-  hidden,
-  images,
-  implementation,
-  lastElementChild,
-  links,
-  pictureInPictureElement,
-  pictureInPictureEnabled,
-  plugins,
-  pointerLockElement,
-  prerendering,
-  scripts,
-  scrollingElement,
-  styleSheets,
-  timeline,
-  visibilityState,
-  cookie,
-  defaultView,
-  designMode,
-  dir,
-  fullscreenEnabled,
-  lastModified,
-  location,
-  readyState,
-  referrer,
-  title,
-  URL,
-} from "../../src/document";
 import * as documentModule from "../../src/document";
 import { expect, test } from "bun:test";
 
 test("Document returns global Document", () => {
   function MyDoc() {}
   (globalThis as any).Document = MyDoc;
-  expect(Document()).toBe(MyDoc);
+  expect(documentModule.Document()).toBe(MyDoc);
 });
 
 test("activeElement returns document.activeElement", () => {
   (globalThis as any).document = { activeElement: "el" };
-  expect(activeElement()).toBe("el");
+  expect(documentModule.activeElement()).toBe("el");
 });
 
 test("adoptedStyleSheets returns document.adoptedStyleSheets", () => {
   (globalThis as any).document = { adoptedStyleSheets: [1,2,3] };
-  expect(adoptedStyleSheets()).toEqual([1,2,3]);
+  expect(documentModule.adoptedStyleSheets()).toEqual([1,2,3]);
 });
 
 test("adoptNode calls document.adoptNode", () => {
   (globalThis as any).document = { adoptNode: (n: any) => ({ node: n }) };
-  expect(adoptNode("n")).toEqual({ node: "n" });
+  expect(documentModule.adoptNode("n")).toEqual({ node: "n" });
 });
 test("adoptNodeFrom calls adoptNode on passed document", () => {
   const doc: any = { adoptNode: (x: any) => `ad:${x}` };
@@ -103,7 +28,7 @@ test("adoptNodeFrom calls adoptNode on passed document", () => {
 
 test("append calls document.append", () => {
   (globalThis as any).document = { append: (...a: any[]) => a.join("-") };
-  expect(append("a", "b")).toBe("a-b");
+  expect(documentModule.append("a", "b")).toBe("a-b");
 });
 test("appendFrom calls append on passed document", () => {
   const doc: any = { append: (...a: any[]) => a.length };
@@ -112,7 +37,7 @@ test("appendFrom calls append on passed document", () => {
 
 test("browsingTopics calls document.browsingTopics", () => {
   (globalThis as any).document = { browsingTopics: () => [1] };
-  expect(browsingTopics()).toEqual([1]);
+  expect(documentModule.browsingTopics()).toEqual([1]);
 });
 test("browsingTopicsFrom calls browsingTopics on passed document", () => {
   const doc: any = { browsingTopics: () => [2] };
@@ -123,7 +48,7 @@ test("caretPositionFromPoint calls document.caretPositionFromPoint", () => {
   (globalThis as any).document = {
     caretPositionFromPoint: (x: any, y: any) => x + y,
   };
-  expect(caretPositionFromPoint(1, 2)).toBe(3);
+  expect(documentModule.caretPositionFromPoint(1, 2)).toBe(3);
 });
 test("caretPositionFromPointFrom calls caretPositionFromPoint on passed document", () => {
   const doc: any = { caretPositionFromPoint: (x: any, y: any) => x * y };
@@ -134,7 +59,7 @@ test("caretRangeFromPoint calls document.caretRangeFromPoint", () => {
   (globalThis as any).document = {
     caretRangeFromPoint: (x: any, y: any) => `${x},${y}`,
   };
-  expect(caretRangeFromPoint(1, 1)).toBe("1,1");
+  expect(documentModule.caretRangeFromPoint(1, 1)).toBe("1,1");
 });
 test("caretRangeFromPointFrom calls caretRangeFromPoint on passed document", () => {
   const doc: any = { caretRangeFromPoint: () => "r" };
@@ -143,7 +68,7 @@ test("caretRangeFromPointFrom calls caretRangeFromPoint on passed document", () 
 
 test("createAttribute calls document.createAttribute", () => {
   (globalThis as any).document = { createAttribute: (n: any) => ({ n }) };
-  expect(createAttribute("id")).toEqual({ n: "id" });
+  expect(documentModule.createAttribute("id")).toEqual({ n: "id" });
 });
 test("createAttributeFrom calls createAttribute on passed document", () => {
   const doc: any = { createAttribute: (n: any) => n.toUpperCase() };
@@ -152,7 +77,7 @@ test("createAttributeFrom calls createAttribute on passed document", () => {
 
 test("createAttributeNS calls document.createAttributeNS", () => {
   (globalThis as any).document = { createAttributeNS: (ns: any, n: any) => ns+n };
-  expect(createAttributeNS("ns", "n")).toBe("nsn");
+  expect(documentModule.createAttributeNS("ns", "n")).toBe("nsn");
 });
 test("createAttributeNSFrom calls createAttributeNS on passed document", () => {
   const doc: any = { createAttributeNS: (ns: any, n: any) => `${ns}:${n}` };
@@ -161,7 +86,7 @@ test("createAttributeNSFrom calls createAttributeNS on passed document", () => {
 
 test("createCDATASection calls document.createCDATASection", () => {
   (globalThis as any).document = { createCDATASection: (t: any) => `<${t}>` };
-  expect(createCDATASection("c")).toBe("<c>");
+  expect(documentModule.createCDATASection("c")).toBe("<c>");
 });
 test("createCDATASectionFrom calls createCDATASection on passed document", () => {
   const doc: any = { createCDATASection: (t: any) => t };
@@ -170,7 +95,7 @@ test("createCDATASectionFrom calls createCDATASection on passed document", () =>
 
 test("createComment calls document.createComment", () => {
   (globalThis as any).document = { createComment: (t: any) => `c:${t}` };
-  expect(createComment("m")).toBe("c:m");
+  expect(documentModule.createComment("m")).toBe("c:m");
 });
 test("createCommentFrom calls createComment on passed document", () => {
   const doc: any = { createComment: () => "d" };
@@ -179,7 +104,7 @@ test("createCommentFrom calls createComment on passed document", () => {
 
 test("createDocumentFragment calls document.createDocumentFragment", () => {
   (globalThis as any).document = { createDocumentFragment: () => "frag" };
-  expect(createDocumentFragment()).toBe("frag");
+  expect(documentModule.createDocumentFragment()).toBe("frag");
 });
 test("createDocumentFragmentFrom calls createDocumentFragment on passed document", () => {
   const doc: any = { createDocumentFragment: () => "df" };
@@ -188,7 +113,7 @@ test("createDocumentFragmentFrom calls createDocumentFragment on passed document
 
 test("createElement calls document.createElement", () => {
   (globalThis as any).document = { createElement: (t: any) => ({ t }) };
-  expect(createElement("div")).toEqual({ t: "div" });
+  expect(documentModule.createElement("div")).toEqual({ t: "div" });
 });
 test("createElementFrom calls createElement on passed document", () => {
   const doc: any = { createElement: (t: any) => t + t };
@@ -197,7 +122,7 @@ test("createElementFrom calls createElement on passed document", () => {
 
 test("createElementNS calls document.createElementNS", () => {
   (globalThis as any).document = { createElementNS: (ns: any, q: any) => ns+q };
-  expect(createElementNS("s", "q")).toBe("sq");
+  expect(documentModule.createElementNS("s", "q")).toBe("sq");
 });
 test("createElementNSFrom calls createElementNS on passed document", () => {
   const doc: any = { createElementNS: (ns: any, q: any) => `${ns}/${q}` };
@@ -206,7 +131,7 @@ test("createElementNSFrom calls createElementNS on passed document", () => {
 
 test("createEvent calls document.createEvent", () => {
   (globalThis as any).document = { createEvent: (t: any) => ({ e: t }) };
-  expect(createEvent("evt")).toEqual({ e: "evt" });
+  expect(documentModule.createEvent("evt")).toEqual({ e: "evt" });
 });
 test("createEventFrom calls createEvent on passed document", () => {
   const doc: any = { createEvent: (t: any) => t };
@@ -215,7 +140,7 @@ test("createEventFrom calls createEvent on passed document", () => {
 
 test("createNodeIterator calls document.createNodeIterator", () => {
   (globalThis as any).document = { createNodeIterator: (n: any) => ({ n }) };
-  expect(createNodeIterator("n")).toEqual({ n: "n" });
+  expect(documentModule.createNodeIterator("n")).toEqual({ n: "n" });
 });
 test("createNodeIteratorFrom calls createNodeIterator on passed document", () => {
   const doc: any = { createNodeIterator: (n: any) => n + "F" };
@@ -224,7 +149,7 @@ test("createNodeIteratorFrom calls createNodeIterator on passed document", () =>
 
 test("createProcessingInstruction calls document.createProcessingInstruction", () => {
   (globalThis as any).document = { createProcessingInstruction: (t: any, d: any) => `${t}:${d}` };
-  expect(createProcessingInstruction("t","d")).toBe("t:d");
+  expect(documentModule.createProcessingInstruction("t","d")).toBe("t:d");
 });
 test("createProcessingInstructionFrom calls createProcessingInstruction on passed document", () => {
   const doc: any = { createProcessingInstruction: () => "pi" };
@@ -233,7 +158,7 @@ test("createProcessingInstructionFrom calls createProcessingInstruction on passe
 
 test("createRange calls document.createRange", () => {
   (globalThis as any).document = { createRange: () => "R" };
-  expect(createRange()).toBe("R");
+  expect(documentModule.createRange()).toBe("R");
 });
 test("createRangeFrom calls createRange on passed document", () => {
   const doc: any = { createRange: () => "DR" };
@@ -242,7 +167,7 @@ test("createRangeFrom calls createRange on passed document", () => {
 
 test("createTextNode calls document.createTextNode", () => {
   (globalThis as any).document = { createTextNode: (t: any) => t + t };
-  expect(createTextNode("a")).toBe("aa");
+  expect(documentModule.createTextNode("a")).toBe("aa");
 });
 test("createTextNodeFrom calls createTextNode on passed document", () => {
   const doc: any = { createTextNode: (t: any) => t.toUpperCase() };
@@ -251,7 +176,7 @@ test("createTextNodeFrom calls createTextNode on passed document", () => {
 
 test("createTouch calls document.createTouch", () => {
   (globalThis as any).document = { createTouch: (v: any) => ({ v }) };
-  expect(createTouch(1)).toEqual({ v: 1 });
+  expect(documentModule.createTouch(1)).toEqual({ v: 1 });
 });
 test("createTouchFrom calls createTouch on passed document", () => {
   const doc: any = { createTouch: (v: any) => ({ dv: v }) };
@@ -260,7 +185,7 @@ test("createTouchFrom calls createTouch on passed document", () => {
 
 test("createTouchList calls document.createTouchList", () => {
   (globalThis as any).document = { createTouchList: (...a: any[]) => a.length };
-  expect(createTouchList(1,2)).toBe(2);
+  expect(documentModule.createTouchList(1,2)).toBe(2);
 });
 test("createTouchListFrom calls createTouchList on passed document", () => {
   const doc: any = { createTouchList: () => 5 };
@@ -269,7 +194,7 @@ test("createTouchListFrom calls createTouchList on passed document", () => {
 
 test("createTreeWalker calls document.createTreeWalker", () => {
   (globalThis as any).document = { createTreeWalker: (n: any) => ({ node: n }) };
-  expect(createTreeWalker("n")).toEqual({ node: "n" });
+  expect(documentModule.createTreeWalker("n")).toEqual({ node: "n" });
 });
 test("createTreeWalkerFrom calls createTreeWalker on passed document", () => {
   const doc: any = { createTreeWalker: () => "tw" };
@@ -278,62 +203,62 @@ test("createTreeWalkerFrom calls createTreeWalker on passed document", () => {
 
 test("body returns document.body", () => {
   (globalThis as any).document = { body: "b" };
-  expect(body()).toBe("b");
+  expect(documentModule.body()).toBe("b");
 });
 
 test("characterSet returns document.characterSet", () => {
   (globalThis as any).document = { characterSet: "UTF-8" };
-  expect(characterSet()).toBe("UTF-8");
+  expect(documentModule.characterSet()).toBe("UTF-8");
 });
 
 test("childElementCount returns document.childElementCount", () => {
   (globalThis as any).document = { childElementCount: 5 };
-  expect(childElementCount()).toBe(5);
+  expect(documentModule.childElementCount()).toBe(5);
 });
 
 test("children returns document.children", () => {
   (globalThis as any).document = { children: ["a", "b"] };
-  expect(children()).toEqual(["a", "b"]);
+  expect(documentModule.children()).toEqual(["a", "b"]);
 });
 
 test("compatMode returns document.compatMode", () => {
   (globalThis as any).document = { compatMode: "CSS1Compat" };
-  expect(compatMode()).toBe("CSS1Compat");
+  expect(documentModule.compatMode()).toBe("CSS1Compat");
 });
 
 test("contentType returns document.contentType", () => {
   (globalThis as any).document = { contentType: "text/html" };
-  expect(contentType()).toBe("text/html");
+  expect(documentModule.contentType()).toBe("text/html");
 });
 
 test("currentScript returns document.currentScript", () => {
   (globalThis as any).document = { currentScript: "script.js" };
-  expect(currentScript()).toBe("script.js");
+  expect(documentModule.currentScript()).toBe("script.js");
 });
 
 test("doctype returns document.doctype", () => {
   (globalThis as any).document = { doctype: "doctype" };
-  expect(doctype()).toBe("doctype");
+  expect(documentModule.doctype()).toBe("doctype");
 });
 
 test("documentElement returns document.documentElement", () => {
   (globalThis as any).document = { documentElement: { node: true } };
-  expect(documentElement()).toEqual({ node: true });
+  expect(documentModule.documentElement()).toEqual({ node: true });
 });
 
 test("documentURI returns document.documentURI", () => {
   (globalThis as any).document = { documentURI: "http://example" };
-  expect(documentURI()).toBe("http://example");
+  expect(documentModule.documentURI()).toBe("http://example");
 });
 
 test("embeds returns document.embeds", () => {
   (globalThis as any).document = { embeds: [1, 2] };
-  expect(embeds()).toEqual([1, 2]);
+  expect(documentModule.embeds()).toEqual([1, 2]);
 });
 
 test("elementFromPoint calls document.elementFromPoint", () => {
   (globalThis as any).document = { elementFromPoint: (x: any, y: any) => `${x}-${y}` };
-  expect(elementFromPoint(1,2)).toBe("1-2");
+  expect(documentModule.elementFromPoint(1,2)).toBe("1-2");
 });
 test("elementFromPointFrom calls elementFromPoint on passed document", () => {
   const doc: any = { elementFromPoint: () => "el" };
@@ -342,7 +267,7 @@ test("elementFromPointFrom calls elementFromPoint on passed document", () => {
 
 test("elementsFromPoint calls document.elementsFromPoint", () => {
   (globalThis as any).document = { elementsFromPoint: () => ["a"] };
-  expect(elementsFromPoint()).toEqual(["a"]);
+  expect(documentModule.elementsFromPoint()).toEqual(["a"]);
 });
 test("elementsFromPointFrom calls elementsFromPoint on passed document", () => {
   const doc: any = { elementsFromPoint: () => ["b"] };
@@ -351,7 +276,7 @@ test("elementsFromPointFrom calls elementsFromPoint on passed document", () => {
 
 test("enableStyleSheetsForSet calls document.enableStyleSheetsForSet", () => {
   (globalThis as any).document = { enableStyleSheetsForSet: (s: any) => s };
-  expect(enableStyleSheetsForSet("set")).toBe("set");
+  expect(documentModule.enableStyleSheetsForSet("set")).toBe("set");
 });
 test("enableStyleSheetsForSetFrom calls enableStyleSheetsForSet on passed document", () => {
   const doc: any = { enableStyleSheetsForSet: (s: any) => `d:${s}` };
@@ -360,7 +285,7 @@ test("enableStyleSheetsForSetFrom calls enableStyleSheetsForSet on passed docume
 
 test("exitFullscreen calls document.exitFullscreen", () => {
   (globalThis as any).document = { exitFullscreen: () => "ef" };
-  expect(exitFullscreen()).toBe("ef");
+  expect(documentModule.exitFullscreen()).toBe("ef");
 });
 test("exitFullscreenFrom calls exitFullscreen on passed document", () => {
   const doc: any = { exitFullscreen: () => "wf" };
@@ -369,7 +294,7 @@ test("exitFullscreenFrom calls exitFullscreen on passed document", () => {
 
 test("exitPictureInPicture calls document.exitPictureInPicture", () => {
   (globalThis as any).document = { exitPictureInPicture: () => 1 };
-  expect(exitPictureInPicture()).toBe(1);
+  expect(documentModule.exitPictureInPicture()).toBe(1);
 });
 test("exitPictureInPictureFrom calls exitPictureInPicture on passed document", () => {
   const doc: any = { exitPictureInPicture: () => 2 };
@@ -378,7 +303,7 @@ test("exitPictureInPictureFrom calls exitPictureInPicture on passed document", (
 
 test("exitPointerLock calls document.exitPointerLock", () => {
   (globalThis as any).document = { exitPointerLock: () => "pl" };
-  expect(exitPointerLock()).toBe("pl");
+  expect(documentModule.exitPointerLock()).toBe("pl");
 });
 test("exitPointerLockFrom calls exitPointerLock on passed document", () => {
   const doc: any = { exitPointerLock: () => "dpl" };
@@ -387,167 +312,167 @@ test("exitPointerLockFrom calls exitPointerLock on passed document", () => {
 
 test("featurePolicy returns document.featurePolicy", () => {
   (globalThis as any).document = { featurePolicy: { features: true } };
-  expect(featurePolicy()).toEqual({ features: true });
+  expect(documentModule.featurePolicy()).toEqual({ features: true });
 });
 
 test("firstElementChild returns document.firstElementChild", () => {
   (globalThis as any).document = { firstElementChild: { child: 1 } };
-  expect(firstElementChild()).toEqual({ child: 1 });
+  expect(documentModule.firstElementChild()).toEqual({ child: 1 });
 });
 
 test("fonts returns document.fonts", () => {
   (globalThis as any).document = { fonts: ["Arial"] };
-  expect(fonts()).toEqual(["Arial"]);
+  expect(documentModule.fonts()).toEqual(["Arial"]);
 });
 
 test("forms returns document.forms", () => {
   (globalThis as any).document = { forms: [1, 2] };
-  expect(forms()).toEqual([1, 2]);
+  expect(documentModule.forms()).toEqual([1, 2]);
 });
 
 test("fragmentDirective returns document.fragmentDirective", () => {
   (globalThis as any).document = { fragmentDirective: { text: "d" } };
-  expect(fragmentDirective()).toEqual({ text: "d" });
+  expect(documentModule.fragmentDirective()).toEqual({ text: "d" });
 });
 
 test("fullscreenElement returns document.fullscreenElement", () => {
   (globalThis as any).document = { fullscreenElement: { el: true } };
-  expect(fullscreenElement()).toEqual({ el: true });
+  expect(documentModule.fullscreenElement()).toEqual({ el: true });
 });
 
 test("head returns document.head", () => {
   (globalThis as any).document = { head: { head: true } };
-  expect(head()).toEqual({ head: true });
+  expect(documentModule.head()).toEqual({ head: true });
 });
 
 test("hidden returns document.hidden", () => {
   (globalThis as any).document = { hidden: false };
-  expect(hidden()).toBe(false);
+  expect(documentModule.hidden()).toBe(false);
 });
 
 test("images returns document.images", () => {
   (globalThis as any).document = { images: [1, 2] };
-  expect(images()).toEqual([1, 2]);
+  expect(documentModule.images()).toEqual([1, 2]);
 });
 
 test("implementation returns document.implementation", () => {
   (globalThis as any).document = { implementation: { impl: true } };
-  expect(implementation()).toEqual({ impl: true });
+  expect(documentModule.implementation()).toEqual({ impl: true });
 });
 
 test("lastElementChild returns document.lastElementChild", () => {
   (globalThis as any).document = { lastElementChild: { last: 1 } };
-  expect(lastElementChild()).toEqual({ last: 1 });
+  expect(documentModule.lastElementChild()).toEqual({ last: 1 });
 });
 
 test("links returns document.links", () => {
   (globalThis as any).document = { links: ["a"] };
-  expect(links()).toEqual(["a"]);
+  expect(documentModule.links()).toEqual(["a"]);
 });
 
 test("pictureInPictureElement returns document.pictureInPictureElement", () => {
   (globalThis as any).document = { pictureInPictureElement: { pip: true } };
-  expect(pictureInPictureElement()).toEqual({ pip: true });
+  expect(documentModule.pictureInPictureElement()).toEqual({ pip: true });
 });
 
 test("pictureInPictureEnabled returns document.pictureInPictureEnabled", () => {
   (globalThis as any).document = { pictureInPictureEnabled: true };
-  expect(pictureInPictureEnabled()).toBe(true);
+  expect(documentModule.pictureInPictureEnabled()).toBe(true);
 });
 
 test("plugins returns document.plugins", () => {
   (globalThis as any).document = { plugins: [1] };
-  expect(plugins()).toEqual([1]);
+  expect(documentModule.plugins()).toEqual([1]);
 });
 
 test("pointerLockElement returns document.pointerLockElement", () => {
   (globalThis as any).document = { pointerLockElement: { el: 1 } };
-  expect(pointerLockElement()).toEqual({ el: 1 });
+  expect(documentModule.pointerLockElement()).toEqual({ el: 1 });
 });
 
 test("prerendering returns document.prerendering", () => {
   (globalThis as any).document = { prerendering: false };
-  expect(prerendering()).toBe(false);
+  expect(documentModule.prerendering()).toBe(false);
 });
 
 test("scripts returns document.scripts", () => {
   (globalThis as any).document = { scripts: ["s"] };
-  expect(scripts()).toEqual(["s"]);
+  expect(documentModule.scripts()).toEqual(["s"]);
 });
 
 test("scrollingElement returns document.scrollingElement", () => {
   (globalThis as any).document = { scrollingElement: { se: 1 } };
-  expect(scrollingElement()).toEqual({ se: 1 });
+  expect(documentModule.scrollingElement()).toEqual({ se: 1 });
 });
 
 test("styleSheets returns document.styleSheets", () => {
   (globalThis as any).document = { styleSheets: ["ss"] };
-  expect(styleSheets()).toEqual(["ss"]);
+  expect(documentModule.styleSheets()).toEqual(["ss"]);
 });
 
 test("timeline returns document.timeline", () => {
   (globalThis as any).document = { timeline: { t: 1 } };
-  expect(timeline()).toEqual({ t: 1 });
+  expect(documentModule.timeline()).toEqual({ t: 1 });
 });
 
 test("visibilityState returns document.visibilityState", () => {
   (globalThis as any).document = { visibilityState: "visible" };
-  expect(visibilityState()).toBe("visible");
+  expect(documentModule.visibilityState()).toBe("visible");
 });
 
 test("cookie returns document.cookie", () => {
   (globalThis as any).document = { cookie: "a=b" };
-  expect(cookie()).toBe("a=b");
+  expect(documentModule.cookie()).toBe("a=b");
 });
 
 test("defaultView returns document.defaultView", () => {
   (globalThis as any).document = { defaultView: { win: true } };
-  expect(defaultView()).toEqual({ win: true });
+  expect(documentModule.defaultView()).toEqual({ win: true });
 });
 
 test("designMode returns document.designMode", () => {
   (globalThis as any).document = { designMode: "on" };
-  expect(designMode()).toBe("on");
+  expect(documentModule.designMode()).toBe("on");
 });
 
 test("dir returns document.dir", () => {
   (globalThis as any).document = { dir: "ltr" };
-  expect(dir()).toBe("ltr");
+  expect(documentModule.dir()).toBe("ltr");
 });
 
 test("fullscreenEnabled returns document.fullscreenEnabled", () => {
   (globalThis as any).document = { fullscreenEnabled: true };
-  expect(fullscreenEnabled()).toBe(true);
+  expect(documentModule.fullscreenEnabled()).toBe(true);
 });
 
 test("lastModified returns document.lastModified", () => {
   (globalThis as any).document = { lastModified: "today" };
-  expect(lastModified()).toBe("today");
+  expect(documentModule.lastModified()).toBe("today");
 });
 
 test("location returns document.location", () => {
   (globalThis as any).document = { location: { href: "http://example" } };
-  expect(location()).toEqual({ href: "http://example" });
+  expect(documentModule.location()).toEqual({ href: "http://example" });
 });
 
 test("readyState returns document.readyState", () => {
   (globalThis as any).document = { readyState: "complete" };
-  expect(readyState()).toBe("complete");
+  expect(documentModule.readyState()).toBe("complete");
 });
 
 test("referrer returns document.referrer", () => {
   (globalThis as any).document = { referrer: "http://ref" };
-  expect(referrer()).toBe("http://ref");
+  expect(documentModule.referrer()).toBe("http://ref");
 });
 
 test("title returns document.title", () => {
   (globalThis as any).document = { title: "My Page" };
-  expect(title()).toBe("My Page");
+  expect(documentModule.title()).toBe("My Page");
 });
 
 test("URL returns document.URL", () => {
   (globalThis as any).document = { URL: "http://url" };
-  expect(URL()).toBe("http://url");
+  expect(documentModule.URL()).toBe("http://url");
 });
 
 // New tests for instance-specific document functions

--- a/tests/window/index.test.ts
+++ b/tests/window/index.test.ts
@@ -1,104 +1,9 @@
-import {
-  alert,
-  atob,
-  blur,
-  btoa,
-  cancelAnimationFrame,
-  cancelIdleCallback,
-  caches,
-  clearInterval,
-  clearTimeout,
-  close,
-  confirm,
-  createImageBitmap,
-  clientInformation,
-  closed,
-  cookieStore,
-  credentialless,
-  crossOriginIsolated,
-  crypto,
-  customElements,
-  devicePixelRatio,
-  document,
-  documentPictureInPicture,
-  dump,
-  fence,
-  fetch,
-  fetchLater,
-  find,
-  focus,
-  frameElement,
-  frames,
-  fullScreen,
-  getComputedStyle,
-  getDefaultComputedStyle,
-  getScreenDetails,
-  getSelection,
-  history,
-  indexedDb,
-  innerHeight,
-  innerWidth,
-  isSecureContext,
-  launchQueue,
-  length,
-  localStorage,
-  location,
-  locationbar,
-  matchMedia,
-  menubar,
-  mozInnerScreenX,
-  mozInnerScreenY,
-  moveBy,
-  moveTo,
-  name,
-  navigation,
-  navigator,
-  open,
-  opener,
-  origin,
-  originAgentCluster,
-  outerHeight,
-  outerWidth,
-  pageXOffset,
-  pageYOffset,
-  parent,
-  performance,
-  personalbar,
-  postMessage,
-  print,
-  prompt,
-  queryLocalFonts,
-  queueMicrotask,
-  reportError,
-  requestAnimationFrame,
-  scheduler,
-  screen,
-  screenLeft,
-  screenTop,
-  screenX,
-  screenY,
-  scrollMaxX,
-  scrollMaxY,
-  scrollX,
-  scrollY,
-  scrollbars,
-  self,
-  sessionStorage,
-  sharedStorage,
-  speechSynthesis,
-  statusbar,
-  toolbar,
-  top,
-  trustedTypes,
-  visualViewport,
-  window,
-} from "../../src/window";
 import * as windowModule from "../../src/window";
 import { expect, test } from "bun:test";
 
 test("alert calls global alert", () => {
   (globalThis as any).alert = (m: any) => `A:${m}`;
-  expect(alert("m")).toBe("A:m");
+  expect(windowModule.alert("m")).toBe("A:m");
 });
 test("alertFrom calls alert on passed window", () => {
   const win: any = { alert: (x: any) => `B:${x}` };
@@ -107,7 +12,7 @@ test("alertFrom calls alert on passed window", () => {
 
 test("atob calls global atob", () => {
   (globalThis as any).atob = (d: any) => Buffer.from(d, "base64").toString("binary");
-  expect(atob("YWE=")).toBe("aa");
+  expect(windowModule.atob("YWE=")).toBe("aa");
 });
 test("atobFrom calls atob on passed window", () => {
   const win: any = { atob: (d: any) => Buffer.from(d, "base64").toString("utf8") };
@@ -116,7 +21,7 @@ test("atobFrom calls atob on passed window", () => {
 
 test("blur calls global blur", () => {
   (globalThis as any).blur = () => "BLUR";
-  expect(blur()).toBe("BLUR");
+  expect(windowModule.blur()).toBe("BLUR");
 });
 test("blurFrom calls blur on passed window", () => {
   const win: any = { blur: () => "BLUR2" };
@@ -125,7 +30,7 @@ test("blurFrom calls blur on passed window", () => {
 
 test("btoa calls global btoa", () => {
   (globalThis as any).btoa = (d: any) => `enc:${d}`;
-  expect(btoa("data")).toBe("enc:data");
+  expect(windowModule.btoa("data")).toBe("enc:data");
 });
 test("btoaFrom calls btoa on passed window", () => {
   const win: any = { btoa: (d: any) => `e:${d}` };
@@ -134,7 +39,7 @@ test("btoaFrom calls btoa on passed window", () => {
 
 test("cancelAnimationFrame calls global cancelAnimationFrame", () => {
   (globalThis as any).cancelAnimationFrame = (id: any) => id * 2;
-  expect(cancelAnimationFrame(3)).toBe(6);
+  expect(windowModule.cancelAnimationFrame(3)).toBe(6);
 });
 test("cancelAnimationFrameFrom calls cancelAnimationFrame on passed window", () => {
   const win: any = { cancelAnimationFrame: (id: any) => id + 1 };
@@ -143,7 +48,7 @@ test("cancelAnimationFrameFrom calls cancelAnimationFrame on passed window", () 
 
 test("cancelIdleCallback calls global cancelIdleCallback", () => {
   (globalThis as any).cancelIdleCallback = (id: any) => id - 1;
-  expect(cancelIdleCallback(7)).toBe(6);
+  expect(windowModule.cancelIdleCallback(7)).toBe(6);
 });
 test("cancelIdleCallbackFrom calls cancelIdleCallback on passed window", () => {
   const win: any = { cancelIdleCallback: (id: any) => id + 2 };
@@ -152,7 +57,7 @@ test("cancelIdleCallbackFrom calls cancelIdleCallback on passed window", () => {
 
 test("clearInterval calls global clearInterval", () => {
   (globalThis as any).clearInterval = (id: any) => `ci:${id}`;
-  expect(clearInterval(8)).toBe("ci:8");
+  expect(windowModule.clearInterval(8)).toBe("ci:8");
 });
 test("clearIntervalFrom calls clearInterval on passed window", () => {
   const win: any = { clearInterval: (id: any) => `ciw:${id}` };
@@ -161,7 +66,7 @@ test("clearIntervalFrom calls clearInterval on passed window", () => {
 
 test("clearTimeout calls global clearTimeout", () => {
   (globalThis as any).clearTimeout = (id: any) => `ct:${id}`;
-  expect(clearTimeout(9)).toBe("ct:9");
+  expect(windowModule.clearTimeout(9)).toBe("ct:9");
 });
 test("clearTimeoutFrom calls clearTimeout on passed window", () => {
   const win: any = { clearTimeout: (id: any) => `ctw:${id}` };
@@ -170,7 +75,7 @@ test("clearTimeoutFrom calls clearTimeout on passed window", () => {
 
 test("close calls global close", () => {
   (globalThis as any).close = () => "closed";
-  expect(close()).toBe("closed");
+  expect(windowModule.close()).toBe("closed");
 });
 test("closeFrom calls close on passed window", () => {
   const win: any = { close: () => "c" };
@@ -179,7 +84,7 @@ test("closeFrom calls close on passed window", () => {
 
 test("confirm calls global confirm", () => {
   (globalThis as any).confirm = (msg: any) => msg === "ok";
-  expect(confirm("ok")).toBe(true);
+  expect(windowModule.confirm("ok")).toBe(true);
 });
 test("confirmFrom calls confirm on passed window", () => {
   const win: any = { confirm: (m: any) => m };
@@ -188,7 +93,7 @@ test("confirmFrom calls confirm on passed window", () => {
 
 test("createImageBitmap calls global createImageBitmap", () => {
   (globalThis as any).createImageBitmap = (d: any) => ({ img: d });
-  expect(createImageBitmap("buf")).toEqual({ img: "buf" });
+  expect(windowModule.createImageBitmap("buf")).toEqual({ img: "buf" });
 });
 test("createImageBitmapFrom calls createImageBitmap on passed window", () => {
   const win: any = { createImageBitmap: (b: any) => ({ w: b }) };
@@ -197,62 +102,62 @@ test("createImageBitmapFrom calls createImageBitmap on passed window", () => {
 
 test("caches returns global caches", () => {
   (globalThis as any).caches = "CACHES_TEST";
-  expect(caches()).toBe("CACHES_TEST");
+  expect(windowModule.caches()).toBe("CACHES_TEST");
 });
 
 test("clientInformation returns global clientInformation", () => {
   (globalThis as any).clientInformation = { info: true };
-  expect(clientInformation()).toEqual({ info: true });
+  expect(windowModule.clientInformation()).toEqual({ info: true });
 });
 
 test("closed returns global closed", () => {
   (globalThis as any).closed = true;
-  expect(closed()).toBe(true);
+  expect(windowModule.closed()).toBe(true);
 });
 
 test("cookieStore returns global cookieStore", () => {
   (globalThis as any).cookieStore = { store: 1 };
-  expect(cookieStore()).toEqual({ store: 1 });
+  expect(windowModule.cookieStore()).toEqual({ store: 1 });
 });
 
 test("credentialless returns global credentialless", () => {
   (globalThis as any).credentialless = false;
-  expect(credentialless()).toBe(false);
+  expect(windowModule.credentialless()).toBe(false);
 });
 
 test("crossOriginIsolated returns global crossOriginIsolated", () => {
   (globalThis as any).crossOriginIsolated = true;
-  expect(crossOriginIsolated()).toBe(true);
+  expect(windowModule.crossOriginIsolated()).toBe(true);
 });
 
 test("crypto returns global crypto", () => {
   (globalThis as any).crypto = { crypt: 1 };
-  expect(crypto()).toEqual({ crypt: 1 });
+  expect(windowModule.crypto()).toEqual({ crypt: 1 });
 });
 
 test("customElements returns global customElements", () => {
   (globalThis as any).customElements = { ce: 2 };
-  expect(customElements()).toEqual({ ce: 2 });
+  expect(windowModule.customElements()).toEqual({ ce: 2 });
 });
 
 test("devicePixelRatio returns global devicePixelRatio", () => {
   (globalThis as any).devicePixelRatio = 2;
-  expect(devicePixelRatio()).toBe(2);
+  expect(windowModule.devicePixelRatio()).toBe(2);
 });
 
 test("document returns global document", () => {
   (globalThis as any).document = { doc: true };
-  expect(document()).toEqual({ doc: true });
+  expect(windowModule.document()).toEqual({ doc: true });
 });
 
 test("documentPictureInPicture returns global documentPictureInPicture", () => {
   (globalThis as any).documentPictureInPicture = { pip: true };
-  expect(documentPictureInPicture()).toEqual({ pip: true });
+  expect(windowModule.documentPictureInPicture()).toEqual({ pip: true });
 });
 
 test("dump calls global dump", () => {
   (globalThis as any).dump = (...a: any[]) => a.join("|");
-  expect(dump("a", "b")).toBe("a|b");
+  expect(windowModule.dump("a", "b")).toBe("a|b");
 });
 test("dumpFrom calls dump on passed window", () => {
   const win: any = { dump: (...a: any[]) => a.length };
@@ -261,7 +166,7 @@ test("dumpFrom calls dump on passed window", () => {
 
 test("fetch calls global fetch", () => {
   (globalThis as any).fetch = (u: any) => `F:${u}`;
-  expect(fetch("url")).toBe("F:url");
+  expect(windowModule.fetch("url")).toBe("F:url");
 });
 test("fetchFrom calls fetch on passed window", () => {
   const win: any = { fetch: (u: any) => `WF:${u}` };
@@ -270,7 +175,7 @@ test("fetchFrom calls fetch on passed window", () => {
 
 test("fetchLater calls global fetchLater", () => {
   (globalThis as any).fetchLater = (u: any) => `FL:${u}`;
-  expect(fetchLater("u")).toBe("FL:u");
+  expect(windowModule.fetchLater("u")).toBe("FL:u");
 });
 test("fetchLaterFrom calls fetchLater on passed window", () => {
   const win: any = { fetchLater: (u: any) => `WFL:${u}` };
@@ -279,7 +184,7 @@ test("fetchLaterFrom calls fetchLater on passed window", () => {
 
 test("find calls global find", () => {
   (globalThis as any).find = (t: any) => t.toUpperCase();
-  expect(find("x")).toBe("X");
+  expect(windowModule.find("x")).toBe("X");
 });
 test("findFrom calls find on passed window", () => {
   const win: any = { find: (s: any) => s + s };
@@ -288,7 +193,7 @@ test("findFrom calls find on passed window", () => {
 
 test("focus calls global focus", () => {
   (globalThis as any).focus = () => "FOCUS";
-  expect(focus()).toBe("FOCUS");
+  expect(windowModule.focus()).toBe("FOCUS");
 });
 test("focusFrom calls focus on passed window", () => {
   const win: any = { focus: () => "WF" };
@@ -297,27 +202,27 @@ test("focusFrom calls focus on passed window", () => {
 
 test("fence returns global fence", () => {
   (globalThis as any).fence = { fenced: true };
-  expect(fence()).toEqual({ fenced: true });
+  expect(windowModule.fence()).toEqual({ fenced: true });
 });
 
 test("frameElement returns global frameElement", () => {
   (globalThis as any).frameElement = { frame: 1 };
-  expect(frameElement()).toEqual({ frame: 1 });
+  expect(windowModule.frameElement()).toEqual({ frame: 1 });
 });
 
 test("frames returns global frames", () => {
   (globalThis as any).frames = { window: 1 };
-  expect(frames()).toEqual({ window: 1 });
+  expect(windowModule.frames()).toEqual({ window: 1 });
 });
 
 test("fullScreen returns global fullScreen", () => {
   (globalThis as any).fullScreen = true;
-  expect(fullScreen()).toBe(true);
+  expect(windowModule.fullScreen()).toBe(true);
 });
 
 test("getComputedStyle calls global getComputedStyle", () => {
   (globalThis as any).getComputedStyle = (e: any) => ({ el: e });
-  expect(getComputedStyle("div")).toEqual({ el: "div" });
+  expect(windowModule.getComputedStyle("div")).toEqual({ el: "div" });
 });
 test("getComputedStyleFrom calls getComputedStyle on passed window", () => {
   const win: any = { getComputedStyle: (e: any) => ({ w: e }) };
@@ -326,7 +231,7 @@ test("getComputedStyleFrom calls getComputedStyle on passed window", () => {
 
 test("getDefaultComputedStyle calls global getDefaultComputedStyle", () => {
   (globalThis as any).getDefaultComputedStyle = (e: any) => ({ d: e });
-  expect(getDefaultComputedStyle("el")).toEqual({ d: "el" });
+  expect(windowModule.getDefaultComputedStyle("el")).toEqual({ d: "el" });
 });
 test("getDefaultComputedStyleFrom calls getDefaultComputedStyle on passed window", () => {
   const win: any = { getDefaultComputedStyle: (e: any) => ({ win: e }) };
@@ -335,7 +240,7 @@ test("getDefaultComputedStyleFrom calls getDefaultComputedStyle on passed window
 
 test("getScreenDetails calls global getScreenDetails", () => {
   (globalThis as any).getScreenDetails = () => "scr";
-  expect(getScreenDetails()).toBe("scr");
+  expect(windowModule.getScreenDetails()).toBe("scr");
 });
 test("getScreenDetailsFrom calls getScreenDetails on passed window", () => {
   const win: any = { getScreenDetails: () => "ws" };
@@ -344,7 +249,7 @@ test("getScreenDetailsFrom calls getScreenDetails on passed window", () => {
 
 test("getSelection calls global getSelection", () => {
   (globalThis as any).getSelection = () => "sel";
-  expect(getSelection()).toBe("sel");
+  expect(windowModule.getSelection()).toBe("sel");
 });
 test("getSelectionFrom calls getSelection on passed window", () => {
   const win: any = { getSelection: () => "wsel" };
@@ -353,57 +258,57 @@ test("getSelectionFrom calls getSelection on passed window", () => {
 
 test("history returns global history", () => {
   (globalThis as any).history = { stack: [] };
-  expect(history()).toEqual({ stack: [] });
+  expect(windowModule.history()).toEqual({ stack: [] });
 });
 
 test("indexedDb returns global indexedDB", () => {
   (globalThis as any).indexedDB = { db: 1 };
-  expect(indexedDb()).toEqual({ db: 1 });
+  expect(windowModule.indexedDb()).toEqual({ db: 1 });
 });
 
 test("innerHeight returns global innerHeight", () => {
   (globalThis as any).innerHeight = 480;
-  expect(innerHeight()).toBe(480);
+  expect(windowModule.innerHeight()).toBe(480);
 });
 
 test("innerWidth returns global innerWidth", () => {
   (globalThis as any).innerWidth = 640;
-  expect(innerWidth()).toBe(640);
+  expect(windowModule.innerWidth()).toBe(640);
 });
 
 test("isSecureContext returns global isSecureContext", () => {
   (globalThis as any).isSecureContext = true;
-  expect(isSecureContext()).toBe(true);
+  expect(windowModule.isSecureContext()).toBe(true);
 });
 
 test("launchQueue returns global launchQueue", () => {
   (globalThis as any).launchQueue = { queue: true };
-  expect(launchQueue()).toEqual({ queue: true });
+  expect(windowModule.launchQueue()).toEqual({ queue: true });
 });
 
 test("length returns global length", () => {
   (globalThis as any).length = 42;
-  expect(length()).toBe(42);
+  expect(windowModule.length()).toBe(42);
 });
 
 test("localStorage returns global localStorage", () => {
   (globalThis as any).localStorage = { storage: true };
-  expect(localStorage()).toEqual({ storage: true });
+  expect(windowModule.localStorage()).toEqual({ storage: true });
 });
 
 test("location returns global location", () => {
   (globalThis as any).location = { href: "http://example" };
-  expect(location()).toEqual({ href: "http://example" });
+  expect(windowModule.location()).toEqual({ href: "http://example" });
 });
 
 test("locationbar returns global locationbar", () => {
   (globalThis as any).locationbar = { bar: true };
-  expect(locationbar()).toEqual({ bar: true });
+  expect(windowModule.locationbar()).toEqual({ bar: true });
 });
 
 test("matchMedia calls global matchMedia", () => {
   (globalThis as any).matchMedia = (q: any) => ({ q });
-  expect(matchMedia("m")).toEqual({ q: "m" });
+  expect(windowModule.matchMedia("m")).toEqual({ q: "m" });
 });
 test("matchMediaFrom calls matchMedia on passed window", () => {
   const win: any = { matchMedia: (q: any) => ({ w: q }) };
@@ -412,22 +317,22 @@ test("matchMediaFrom calls matchMedia on passed window", () => {
 
 test("menubar returns global menubar", () => {
   (globalThis as any).menubar = { menu: true };
-  expect(menubar()).toEqual({ menu: true });
+  expect(windowModule.menubar()).toEqual({ menu: true });
 });
 
 test("mozInnerScreenX returns global mozInnerScreenX", () => {
   (globalThis as any).mozInnerScreenX = 1;
-  expect(mozInnerScreenX()).toBe(1);
+  expect(windowModule.mozInnerScreenX()).toBe(1);
 });
 
 test("mozInnerScreenY returns global mozInnerScreenY", () => {
   (globalThis as any).mozInnerScreenY = 2;
-  expect(mozInnerScreenY()).toBe(2);
+  expect(windowModule.mozInnerScreenY()).toBe(2);
 });
 
 test("moveBy calls global moveBy", () => {
   (globalThis as any).moveBy = (x: any, y: any) => x + y;
-  expect(moveBy(1, 2)).toBe(3);
+  expect(windowModule.moveBy(1, 2)).toBe(3);
 });
 test("moveByFrom calls moveBy on passed window", () => {
   const win: any = { moveBy: (x: any, y: any) => x * y };
@@ -436,7 +341,7 @@ test("moveByFrom calls moveBy on passed window", () => {
 
 test("moveTo calls global moveTo", () => {
   (globalThis as any).moveTo = (x: any, y: any) => x - y;
-  expect(moveTo(5, 2)).toBe(3);
+  expect(windowModule.moveTo(5, 2)).toBe(3);
 });
 test("moveToFrom calls moveTo on passed window", () => {
   const win: any = { moveTo: (x: any, y: any) => y - x };
@@ -445,22 +350,22 @@ test("moveToFrom calls moveTo on passed window", () => {
 
 test("name returns global name", () => {
   (globalThis as any).name = "win";
-  expect(name()).toBe("win");
+  expect(windowModule.name()).toBe("win");
 });
 
 test("navigation returns global navigation", () => {
   (globalThis as any).navigation = { nav: true };
-  expect(navigation()).toEqual({ nav: true });
+  expect(windowModule.navigation()).toEqual({ nav: true });
 });
 
 test("navigator returns global navigator", () => {
   (globalThis as any).navigator = { ua: "test" };
-  expect(navigator()).toEqual({ ua: "test" });
+  expect(windowModule.navigator()).toEqual({ ua: "test" });
 });
 
 test("open calls global open", () => {
   (globalThis as any).open = (u: any) => `O:${u}`;
-  expect(open("a")).toBe("O:a");
+  expect(windowModule.open("a")).toBe("O:a");
 });
 test("openFrom calls open on passed window", () => {
   const win: any = { open: (u: any) => `W:${u}` };
@@ -469,57 +374,57 @@ test("openFrom calls open on passed window", () => {
 
 test("opener returns global opener", () => {
   (globalThis as any).opener = { win: 1 };
-  expect(opener()).toEqual({ win: 1 });
+  expect(windowModule.opener()).toEqual({ win: 1 });
 });
 
 test("origin returns global origin", () => {
   (globalThis as any).origin = "http://example";
-  expect(origin()).toBe("http://example");
+  expect(windowModule.origin()).toBe("http://example");
 });
 
 test("originAgentCluster returns global originAgentCluster", () => {
   (globalThis as any).originAgentCluster = { cluster: true };
-  expect(originAgentCluster()).toEqual({ cluster: true });
+  expect(windowModule.originAgentCluster()).toEqual({ cluster: true });
 });
 
 test("outerHeight returns global outerHeight", () => {
   (globalThis as any).outerHeight = 800;
-  expect(outerHeight()).toBe(800);
+  expect(windowModule.outerHeight()).toBe(800);
 });
 
 test("outerWidth returns global outerWidth", () => {
   (globalThis as any).outerWidth = 1024;
-  expect(outerWidth()).toBe(1024);
+  expect(windowModule.outerWidth()).toBe(1024);
 });
 
 test("pageXOffset returns global pageXOffset", () => {
   (globalThis as any).pageXOffset = 10;
-  expect(pageXOffset()).toBe(10);
+  expect(windowModule.pageXOffset()).toBe(10);
 });
 
 test("pageYOffset returns global pageYOffset", () => {
   (globalThis as any).pageYOffset = 20;
-  expect(pageYOffset()).toBe(20);
+  expect(windowModule.pageYOffset()).toBe(20);
 });
 
 test("parent returns global parent", () => {
   (globalThis as any).parent = { parent: true };
-  expect(parent()).toEqual({ parent: true });
+  expect(windowModule.parent()).toEqual({ parent: true });
 });
 
 test("performance returns global performance", () => {
   (globalThis as any).performance = { perf: 1 };
-  expect(performance()).toEqual({ perf: 1 });
+  expect(windowModule.performance()).toEqual({ perf: 1 });
 });
 
 test("personalbar returns global personalbar", () => {
   (globalThis as any).personalbar = { bar: 1 };
-  expect(personalbar()).toEqual({ bar: 1 });
+  expect(windowModule.personalbar()).toEqual({ bar: 1 });
 });
 
 test("postMessage calls global postMessage", () => {
   (globalThis as any).postMessage = (m: any) => `P:${m}`;
-  expect(postMessage("msg")).toBe("P:msg");
+  expect(windowModule.postMessage("msg")).toBe("P:msg");
 });
 test("postMessageFrom calls postMessage on passed window", () => {
   const win: any = { postMessage: (m: any) => `WP:${m}` };
@@ -528,7 +433,7 @@ test("postMessageFrom calls postMessage on passed window", () => {
 
 test("print calls global print", () => {
   (globalThis as any).print = () => "PRINT";
-  expect(print()).toBe("PRINT");
+  expect(windowModule.print()).toBe("PRINT");
 });
 test("printFrom calls print on passed window", () => {
   const win: any = { print: () => "WPRINT" };
@@ -537,7 +442,7 @@ test("printFrom calls print on passed window", () => {
 
 test("prompt calls global prompt", () => {
   (globalThis as any).prompt = () => "PROMPT";
-  expect(prompt()).toBe("PROMPT");
+  expect(windowModule.prompt()).toBe("PROMPT");
 });
 test("promptFrom calls prompt on passed window", () => {
   const win: any = { prompt: () => "WP" };
@@ -546,7 +451,7 @@ test("promptFrom calls prompt on passed window", () => {
 
 test("queryLocalFonts calls global queryLocalFonts", () => {
   (globalThis as any).queryLocalFonts = () => [1];
-  expect(queryLocalFonts()).toEqual([1]);
+  expect(windowModule.queryLocalFonts()).toEqual([1]);
 });
 test("queryLocalFontsFrom calls queryLocalFonts on passed window", () => {
   const win: any = { queryLocalFonts: () => [2] };
@@ -556,7 +461,7 @@ test("queryLocalFontsFrom calls queryLocalFonts on passed window", () => {
 test("queueMicrotask calls global queueMicrotask", () => {
   (globalThis as any).queueMicrotask = (cb: any) => cb("q");
   let val = "";
-  queueMicrotask((v: any) => (val = v));
+  windowModule.queueMicrotask((v: any) => (val = v));
   expect(val).toBe("q");
 });
 test("queueMicrotaskFrom calls queueMicrotask on passed window", () => {
@@ -568,7 +473,7 @@ test("queueMicrotaskFrom calls queueMicrotask on passed window", () => {
 
 test("reportError calls global reportError", () => {
   (globalThis as any).reportError = (e: any) => `R:${e}`;
-  expect(reportError("err")).toBe("R:err");
+  expect(windowModule.reportError("err")).toBe("R:err");
 });
 test("reportErrorFrom calls reportError on passed window", () => {
   const win: any = { reportError: (e: any) => `WR:${e}` };
@@ -578,7 +483,7 @@ test("reportErrorFrom calls reportError on passed window", () => {
 test("requestAnimationFrame calls global requestAnimationFrame", () => {
   (globalThis as any).requestAnimationFrame = (cb: any) => cb(3);
   let r = 0;
-  requestAnimationFrame((v: any) => (r = v));
+  windowModule.requestAnimationFrame((v: any) => (r = v));
   expect(r).toBe(3);
 });
 test("requestAnimationFrameFrom calls requestAnimationFrame on passed window", () => {
@@ -590,107 +495,107 @@ test("requestAnimationFrameFrom calls requestAnimationFrame on passed window", (
 
 test("scheduler returns global scheduler", () => {
   (globalThis as any).scheduler = { schedule: true };
-  expect(scheduler()).toEqual({ schedule: true });
+  expect(windowModule.scheduler()).toEqual({ schedule: true });
 });
 
 test("screen returns global screen", () => {
   (globalThis as any).screen = { colorDepth: 24 };
-  expect(screen()).toEqual({ colorDepth: 24 });
+  expect(windowModule.screen()).toEqual({ colorDepth: 24 });
 });
 
 test("screenLeft returns global screenLeft", () => {
   (globalThis as any).screenLeft = 10;
-  expect(screenLeft()).toBe(10);
+  expect(windowModule.screenLeft()).toBe(10);
 });
 
 test("screenTop returns global screenTop", () => {
   (globalThis as any).screenTop = 20;
-  expect(screenTop()).toBe(20);
+  expect(windowModule.screenTop()).toBe(20);
 });
 
 test("screenX returns global screenX", () => {
   (globalThis as any).screenX = 30;
-  expect(screenX()).toBe(30);
+  expect(windowModule.screenX()).toBe(30);
 });
 
 test("screenY returns global screenY", () => {
   (globalThis as any).screenY = 40;
-  expect(screenY()).toBe(40);
+  expect(windowModule.screenY()).toBe(40);
 });
 
 test("scrollMaxX returns global scrollMaxX", () => {
   (globalThis as any).scrollMaxX = 50;
-  expect(scrollMaxX()).toBe(50);
+  expect(windowModule.scrollMaxX()).toBe(50);
 });
 
 test("scrollMaxY returns global scrollMaxY", () => {
   (globalThis as any).scrollMaxY = 60;
-  expect(scrollMaxY()).toBe(60);
+  expect(windowModule.scrollMaxY()).toBe(60);
 });
 
 test("scrollX returns global scrollX", () => {
   (globalThis as any).scrollX = 70;
-  expect(scrollX()).toBe(70);
+  expect(windowModule.scrollX()).toBe(70);
 });
 
 test("scrollY returns global scrollY", () => {
   (globalThis as any).scrollY = 80;
-  expect(scrollY()).toBe(80);
+  expect(windowModule.scrollY()).toBe(80);
 });
 
 test("scrollbars returns global scrollbars", () => {
   (globalThis as any).scrollbars = { present: true };
-  expect(scrollbars()).toEqual({ present: true });
+  expect(windowModule.scrollbars()).toEqual({ present: true });
 });
 
 test("self returns global self", () => {
   (globalThis as any).self = { self: true };
-  expect(self()).toEqual({ self: true });
+  expect(windowModule.self()).toEqual({ self: true });
 });
 
 test("sessionStorage returns global sessionStorage", () => {
   (globalThis as any).sessionStorage = { session: 1 };
-  expect(sessionStorage()).toEqual({ session: 1 });
+  expect(windowModule.sessionStorage()).toEqual({ session: 1 });
 });
 
 test("sharedStorage returns global sharedStorage", () => {
   (globalThis as any).sharedStorage = { shared: true };
-  expect(sharedStorage()).toEqual({ shared: true });
+  expect(windowModule.sharedStorage()).toEqual({ shared: true });
 });
 
 test("speechSynthesis returns global speechSynthesis", () => {
   (globalThis as any).speechSynthesis = { speak: true };
-  expect(speechSynthesis()).toEqual({ speak: true });
+  expect(windowModule.speechSynthesis()).toEqual({ speak: true });
 });
 
 test("statusbar returns global statusbar", () => {
   (globalThis as any).statusbar = { visible: false };
-  expect(statusbar()).toEqual({ visible: false });
+  expect(windowModule.statusbar()).toEqual({ visible: false });
 });
 
 test("toolbar returns global toolbar", () => {
   (globalThis as any).toolbar = { tools: 1 };
-  expect(toolbar()).toEqual({ tools: 1 });
+  expect(windowModule.toolbar()).toEqual({ tools: 1 });
 });
 
 test("top returns global top", () => {
   (globalThis as any).top = { top: true };
-  expect(top()).toEqual({ top: true });
+  expect(windowModule.top()).toEqual({ top: true });
 });
 
 test("trustedTypes returns global trustedTypes", () => {
   (globalThis as any).trustedTypes = { trust: true };
-  expect(trustedTypes()).toEqual({ trust: true });
+  expect(windowModule.trustedTypes()).toEqual({ trust: true });
 });
 
 test("visualViewport returns global visualViewport", () => {
   (globalThis as any).visualViewport = { height: 100 };
-  expect(visualViewport()).toEqual({ height: 100 });
+  expect(windowModule.visualViewport()).toEqual({ height: 100 });
 });
 
 test("window returns global window", () => {
   (globalThis as any).window = { w: 1 };
-  expect(window()).toEqual({ w: 1 });
+  expect(windowModule.window()).toEqual({ w: 1 });
 });
 
 // New tests for instance-specific functions


### PR DESCRIPTION
## Summary
- remove named imports from test files
- call methods via `documentModule` or `windowModule`

## Testing
- `bun test`