### PR TITLE
Add eventTarget wrappers

### DIFF
--- a/src/eventTarget/index.ts
+++ b/src/eventTarget/index.ts
@@ -1,0 +1,21 @@
+export function addEventListener(...args: any[]): unknown {
+  return (globalThis as any).addEventListener(...args);
+}
+export function addEventListenerTo(target: any, ...args: any[]): unknown {
+  return (target as any).addEventListener(...args);
+}
+
+export function dispatchEvent(...args: any[]): unknown {
+  return (globalThis as any).dispatchEvent(...args);
+}
+export function dispatchEventTo(target: any, ...args: any[]): unknown {
+  return (target as any).dispatchEvent(...args);
+}
+
+export function removeEventListener(...args: any[]): unknown {
+  return (globalThis as any).removeEventListener(...args);
+}
+export function removeEventListenerFrom(target: any, ...args: any[]): unknown {
+  return (target as any).removeEventListener(...args);
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
-export * as window from "./window";
 export * as document from "./document";
+export * as eventTarget from "./eventTarget";
+export * as window from "./window";
+

--- a/tests/eventTarget/index.test.ts
+++ b/tests/eventTarget/index.test.ts
@@ -1,0 +1,33 @@
+import * as eventTargetModule from "../../src/eventTarget";
+import { expect, test } from "bun:test";
+
+test("addEventListener calls global addEventListener", () => {
+  (globalThis as any).addEventListener = (...a: any[]) => a.join("|");
+  expect(eventTargetModule.addEventListener("click", "cb")).toBe("click|cb");
+});
+
+test("addEventListenerTo calls addEventListener on passed target", () => {
+  const tgt: any = { addEventListener: (...a: any[]) => a.length };
+  expect(eventTargetModule.addEventListenerTo(tgt, 1, 2)).toBe(2);
+});
+
+test("dispatchEvent calls global dispatchEvent", () => {
+  (globalThis as any).dispatchEvent = (e: any) => `d:${e.type}`;
+  expect(eventTargetModule.dispatchEvent({ type: "x" })).toBe("d:x");
+});
+
+test("dispatchEventTo calls dispatchEvent on passed target", () => {
+  const tgt: any = { dispatchEvent: (e: any) => e.type };
+  expect(eventTargetModule.dispatchEventTo(tgt, { type: "y" })).toBe("y");
+});
+
+test("removeEventListener calls global removeEventListener", () => {
+  (globalThis as any).removeEventListener = (...a: any[]) => a.join("-");
+  expect(eventTargetModule.removeEventListener("click", "cb")).toBe("click-cb");
+});
+
+test("removeEventListenerFrom calls removeEventListener on passed target", () => {
+  const tgt: any = { removeEventListener: (...a: any[]) => a[0] + a[1] };
+  expect(eventTargetModule.removeEventListenerFrom(tgt, "c", "d")).toBe("cd");
+});
+


### PR DESCRIPTION
## Summary
- wrap `EventTarget` methods for global and instance usage
- export new `eventTarget` module
- test `eventTarget` wrappers
- rename instance wrappers to `addEventListenerTo` and `dispatchEventTo`

## Testing
- `bun test`
