### PR TITLE
Add JSDoc types

### DIFF
--- a/src/document.ffi.mjs
+++ b/src/document.ffi.mjs
@@ -1,737 +1,1804 @@
+/**
+ * Returns `globalThis.Document` from the global context.
+ * @returns {typeof Document}
+ */
 export function Document() {
   return (globalThis).Document;
 }
 
+/**
+ * Returns `document.activeElement` from the global context.
+ * @returns {(Element|null|undefined)}
+ */
 export function activeElement() {
   return (globalThis).document?.activeElement;
 }
+/**
+ * Returns `doc.activeElement` from the provided document.
+ * @param {Document} doc
+ * @returns {(Element|null|undefined)}
+ */
 export function activeElementFrom(doc) {
   return (doc).activeElement;
 }
 
+/**
+ * Returns `document.adoptedStyleSheets` from the global context.
+ * @returns {unknown}
+ */
 export function adoptedStyleSheets() {
   return (globalThis).document?.adoptedStyleSheets;
 }
+/**
+ * Returns `doc.adoptedStyleSheets` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function adoptedStyleSheetsFrom(doc) {
   return (doc).adoptedStyleSheets;
 }
 
+/**
+ * Calls `document.adoptNode()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function adoptNode(...args) {
   return (globalThis).document?.adoptNode(...args);
 }
+/**
+ * Calls `doc.adoptNode()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function adoptNodeFrom(doc, ...args) {
   return (doc).adoptNode(...args);
 }
 
+/**
+ * Calls `document.append()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function append(...args) {
   return (globalThis).document?.append(...args);
 }
+/**
+ * Calls `doc.append()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function appendFrom(doc, ...args) {
   return (doc).append(...args);
 }
 
+/**
+ * Returns `document.body` from the global context.
+ * @returns {(HTMLElement|null|undefined)}
+ */
 export function body() {
   return (globalThis).document?.body;
 }
+/**
+ * Returns `doc.body` from the provided document.
+ * @param {Document} doc
+ * @returns {(HTMLElement|null|undefined)}
+ */
 export function bodyFrom(doc) {
   return (doc).body;
 }
 
+/**
+ * Calls `document.browsingTopics()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function browsingTopics(...args) {
   return (globalThis).document?.browsingTopics(...args);
 }
+/**
+ * Calls `doc.browsingTopics()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function browsingTopicsFrom(doc, ...args) {
   return (doc).browsingTopics(...args);
 }
 
+/**
+ * Calls `document.caretPositionFromPoint()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function caretPositionFromPoint(...args) {
   return (globalThis).document?.caretPositionFromPoint(...args);
 }
+/**
+ * Calls `doc.caretPositionFromPoint()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function caretPositionFromPointFrom(doc, ...args) {
   return (doc).caretPositionFromPoint(...args);
 }
 
+/**
+ * Calls `document.caretRangeFromPoint()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function caretRangeFromPoint(...args) {
   return (globalThis).document?.caretRangeFromPoint(...args);
 }
+/**
+ * Calls `doc.caretRangeFromPoint()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function caretRangeFromPointFrom(doc, ...args) {
   return (doc).caretRangeFromPoint(...args);
 }
 
+/**
+ * Returns `document.characterSet` from the global context.
+ * @returns {(string|undefined)}
+ */
 export function characterSet() {
   return (globalThis).document?.characterSet;
 }
+/**
+ * Returns `doc.characterSet` from the provided document.
+ * @param {Document} doc
+ * @returns {(string|undefined)}
+ */
 export function characterSetFrom(doc) {
   return (doc).characterSet;
 }
 
+/**
+ * Returns `document.childElementCount` from the global context.
+ * @returns {number}
+ */
 export function childElementCount() {
   return (globalThis).document?.childElementCount;
 }
+/**
+ * Returns `doc.childElementCount` from the provided document.
+ * @param {Document} doc
+ * @returns {number}
+ */
 export function childElementCountFrom(doc) {
   return (doc).childElementCount;
 }
 
+/**
+ * Returns `document.children` from the global context.
+ * @returns {unknown}
+ */
 export function children() {
   return (globalThis).document?.children;
 }
+/**
+ * Returns `doc.children` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function childrenFrom(doc) {
   return (doc).children;
 }
 
+/**
+ * Calls `document.clear()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function clear(...args) {
   return (globalThis).document?.clear(...args);
 }
+/**
+ * Calls `doc.clear()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function clearFrom(doc, ...args) {
   return (doc).clear(...args);
 }
 
+/**
+ * Calls `document.close()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function close(...args) {
   return (globalThis).document?.close(...args);
 }
+/**
+ * Calls `doc.close()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function closeFrom(doc, ...args) {
   return (doc).close(...args);
 }
 
+/**
+ * Returns `document.compatMode` from the global context.
+ * @returns {(string|undefined)}
+ */
 export function compatMode() {
   return (globalThis).document?.compatMode;
 }
+/**
+ * Returns `doc.compatMode` from the provided document.
+ * @param {Document} doc
+ * @returns {(string|undefined)}
+ */
 export function compatModeFrom(doc) {
   return (doc).compatMode;
 }
 
+/**
+ * Returns `document.contentType` from the global context.
+ * @returns {(string|undefined)}
+ */
 export function contentType() {
   return (globalThis).document?.contentType;
 }
+/**
+ * Returns `doc.contentType` from the provided document.
+ * @param {Document} doc
+ * @returns {(string|undefined)}
+ */
 export function contentTypeFrom(doc) {
   return (doc).contentType;
 }
 
+/**
+ * Returns `document.cookie` from the global context.
+ * @returns {(string|undefined)}
+ */
 export function cookie() {
   return (globalThis).document?.cookie;
 }
+/**
+ * Returns `doc.cookie` from the provided document.
+ * @param {Document} doc
+ * @returns {(string|undefined)}
+ */
 export function cookieFrom(doc) {
   return (doc).cookie;
 }
 
+/**
+ * Calls `document.createAttribute()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createAttribute(...args) {
   return (globalThis).document?.createAttribute(...args);
 }
+/**
+ * Calls `doc.createAttribute()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createAttributeFrom(doc, ...args) {
   return (doc).createAttribute(...args);
 }
 
+/**
+ * Calls `document.createAttributeNS()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createAttributeNS(...args) {
   return (globalThis).document?.createAttributeNS(...args);
 }
+/**
+ * Calls `doc.createAttributeNS()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createAttributeNSFrom(doc, ...args) {
   return (doc).createAttributeNS(...args);
 }
 
+/**
+ * Calls `document.createCDATASection()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createCDATASection(...args) {
   return (globalThis).document?.createCDATASection(...args);
 }
+/**
+ * Calls `doc.createCDATASection()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createCDATASectionFrom(doc, ...args) {
   return (doc).createCDATASection(...args);
 }
 
+/**
+ * Calls `document.createComment()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createComment(...args) {
   return (globalThis).document?.createComment(...args);
 }
+/**
+ * Calls `doc.createComment()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createCommentFrom(doc, ...args) {
   return (doc).createComment(...args);
 }
 
+/**
+ * Calls `document.createDocumentFragment()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createDocumentFragment(...args) {
   return (globalThis).document?.createDocumentFragment(...args);
 }
+/**
+ * Calls `doc.createDocumentFragment()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createDocumentFragmentFrom(doc, ...args) {
   return (doc).createDocumentFragment(...args);
 }
 
+/**
+ * Calls `document.createElement()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createElement(...args) {
   return (globalThis).document?.createElement(...args);
 }
+/**
+ * Calls `doc.createElement()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createElementFrom(doc, ...args) {
   return (doc).createElement(...args);
 }
 
+/**
+ * Calls `document.createElementNS()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createElementNS(...args) {
   return (globalThis).document?.createElementNS(...args);
 }
+/**
+ * Calls `doc.createElementNS()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createElementNSFrom(doc, ...args) {
   return (doc).createElementNS(...args);
 }
 
+/**
+ * Calls `document.createEvent()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createEvent(...args) {
   return (globalThis).document?.createEvent(...args);
 }
+/**
+ * Calls `doc.createEvent()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createEventFrom(doc, ...args) {
   return (doc).createEvent(...args);
 }
 
+/**
+ * Calls `document.createExpression()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createExpression(...args) {
   return (globalThis).document?.createExpression(...args);
 }
+/**
+ * Calls `doc.createExpression()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createExpressionFrom(doc, ...args) {
   return (doc).createExpression(...args);
 }
 
+/**
+ * Calls `document.createNodeIterator()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createNodeIterator(...args) {
   return (globalThis).document?.createNodeIterator(...args);
 }
+/**
+ * Calls `doc.createNodeIterator()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createNodeIteratorFrom(doc, ...args) {
   return (doc).createNodeIterator(...args);
 }
 
+/**
+ * Calls `document.createNSResolver()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createNSResolver(...args) {
   return (globalThis).document?.createNSResolver(...args);
 }
+/**
+ * Calls `doc.createNSResolver()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createNSResolverFrom(doc, ...args) {
   return (doc).createNSResolver(...args);
 }
 
+/**
+ * Calls `document.createProcessingInstruction()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createProcessingInstruction(...args) {
   return (globalThis).document?.createProcessingInstruction(...args);
 }
+/**
+ * Calls `doc.createProcessingInstruction()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createProcessingInstructionFrom(doc, ...args) {
   return (doc).createProcessingInstruction(...args);
 }
 
+/**
+ * Calls `document.createRange()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createRange(...args) {
   return (globalThis).document?.createRange(...args);
 }
+/**
+ * Calls `doc.createRange()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createRangeFrom(doc, ...args) {
   return (doc).createRange(...args);
 }
 
+/**
+ * Calls `document.createTextNode()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createTextNode(...args) {
   return (globalThis).document?.createTextNode(...args);
 }
+/**
+ * Calls `doc.createTextNode()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createTextNodeFrom(doc, ...args) {
   return (doc).createTextNode(...args);
 }
 
+/**
+ * Calls `document.createTouch()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createTouch(...args) {
   return (globalThis).document?.createTouch(...args);
 }
+/**
+ * Calls `doc.createTouch()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createTouchFrom(doc, ...args) {
   return (doc).createTouch(...args);
 }
 
+/**
+ * Calls `document.createTouchList()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createTouchList(...args) {
   return (globalThis).document?.createTouchList(...args);
 }
+/**
+ * Calls `doc.createTouchList()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createTouchListFrom(doc, ...args) {
   return (doc).createTouchList(...args);
 }
 
+/**
+ * Calls `document.createTreeWalker()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createTreeWalker(...args) {
   return (globalThis).document?.createTreeWalker(...args);
 }
+/**
+ * Calls `doc.createTreeWalker()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createTreeWalkerFrom(doc, ...args) {
   return (doc).createTreeWalker(...args);
 }
 
+/**
+ * Returns `document.currentScript` from the global context.
+ * @returns {unknown}
+ */
 export function currentScript() {
   return (globalThis).document?.currentScript;
 }
+/**
+ * Returns `doc.currentScript` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function currentScriptFrom(doc) {
   return (doc).currentScript;
 }
 
+/**
+ * Returns `document.defaultView` from the global context.
+ * @returns {unknown}
+ */
 export function defaultView() {
   return (globalThis).document?.defaultView;
 }
+/**
+ * Returns `doc.defaultView` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function defaultViewFrom(doc) {
   return (doc).defaultView;
 }
 
+/**
+ * Returns `document.designMode` from the global context.
+ * @returns {unknown}
+ */
 export function designMode() {
   return (globalThis).document?.designMode;
 }
+/**
+ * Returns `doc.designMode` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function designModeFrom(doc) {
   return (doc).designMode;
 }
 
+/**
+ * Returns `document.dir` from the global context.
+ * @returns {unknown}
+ */
 export function dir() {
   return (globalThis).document?.dir;
 }
+/**
+ * Returns `doc.dir` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function dirFrom(doc) {
   return (doc).dir;
 }
 
+/**
+ * Returns `document.doctype` from the global context.
+ * @returns {unknown}
+ */
 export function doctype() {
   return (globalThis).document?.doctype;
 }
+/**
+ * Returns `doc.doctype` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function doctypeFrom(doc) {
   return (doc).doctype;
 }
 
+/**
+ * Returns `document.documentElement` from the global context.
+ * @returns {unknown}
+ */
 export function documentElement() {
   return (globalThis).document?.documentElement;
 }
+/**
+ * Returns `doc.documentElement` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function documentElementFrom(doc) {
   return (doc).documentElement;
 }
 
+/**
+ * Returns `document.documentURI` from the global context.
+ * @returns {unknown}
+ */
 export function documentURI() {
   return (globalThis).document?.documentURI;
 }
+/**
+ * Returns `doc.documentURI` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function documentURIFrom(doc) {
   return (doc).documentURI;
 }
 
+/**
+ * Calls `document.elementsFromPoint()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function elementsFromPoint(...args) {
   return (globalThis).document?.elementsFromPoint(...args);
 }
+/**
+ * Calls `doc.elementsFromPoint()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function elementsFromPointFrom(doc, ...args) {
   return (doc).elementsFromPoint(...args);
 }
 
+/**
+ * Returns `document.embeds` from the global context.
+ * @returns {unknown}
+ */
 export function embeds() {
   return (globalThis).document?.embeds;
 }
+/**
+ * Returns `doc.embeds` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function embedsFrom(doc) {
   return (doc).embeds;
 }
+/**
+ * Calls `document.elementFromPoint()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function elementFromPoint(...args) {
   return (globalThis).document?.elementFromPoint(...args);
 }
+/**
+ * Calls `doc.elementFromPoint()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function elementFromPointFrom(doc, ...args) {
   return (doc).elementFromPoint(...args);
 }
 
+/**
+ * Calls `document.enableStyleSheetsForSet()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function enableStyleSheetsForSet(...args) {
   return (globalThis).document?.enableStyleSheetsForSet(...args);
 }
+/**
+ * Calls `doc.enableStyleSheetsForSet()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function enableStyleSheetsForSetFrom(doc, ...args) {
   return (doc).enableStyleSheetsForSet(...args);
 }
 
+/**
+ * Calls `document.evaluate()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function evaluate(...args) {
   return (globalThis).document?.evaluate(...args);
 }
+/**
+ * Calls `doc.evaluate()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function evaluateFrom(doc, ...args) {
   return (doc).evaluate(...args);
 }
 
+/**
+ * Calls `document.execCommand()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function execCommand(...args) {
   return (globalThis).document?.execCommand(...args);
 }
+/**
+ * Calls `doc.execCommand()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function execCommandFrom(doc, ...args) {
   return (doc).execCommand(...args);
 }
 
+/**
+ * Calls `document.exitFullscreen()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function exitFullscreen(...args) {
   return (globalThis).document?.exitFullscreen(...args);
 }
+/**
+ * Calls `doc.exitFullscreen()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function exitFullscreenFrom(doc, ...args) {
   return (doc).exitFullscreen(...args);
 }
 
+/**
+ * Calls `document.exitPictureInPicture()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function exitPictureInPicture(...args) {
   return (globalThis).document?.exitPictureInPicture(...args);
 }
+/**
+ * Calls `doc.exitPictureInPicture()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function exitPictureInPictureFrom(doc, ...args) {
   return (doc).exitPictureInPicture(...args);
 }
 
+/**
+ * Calls `document.exitPointerLock()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function exitPointerLock(...args) {
   return (globalThis).document?.exitPointerLock(...args);
 }
+/**
+ * Calls `doc.exitPointerLock()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function exitPointerLockFrom(doc, ...args) {
   return (doc).exitPointerLock(...args);
 }
 
+/**
+ * Returns `document.featurePolicy` from the global context.
+ * @returns {unknown}
+ */
 export function featurePolicy() {
   return (globalThis).document?.featurePolicy;
 }
+/**
+ * Returns `doc.featurePolicy` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function featurePolicyFrom(doc) {
   return (doc).featurePolicy;
 }
 
+/**
+ * Returns `document.firstElementChild` from the global context.
+ * @returns {unknown}
+ */
 export function firstElementChild() {
   return (globalThis).document?.firstElementChild;
 }
+/**
+ * Returns `doc.firstElementChild` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function firstElementChildFrom(doc) {
   return (doc).firstElementChild;
 }
 
+/**
+ * Returns `document.fonts` from the global context.
+ * @returns {unknown}
+ */
 export function fonts() {
   return (globalThis).document?.fonts;
 }
+/**
+ * Returns `doc.fonts` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function fontsFrom(doc) {
   return (doc).fonts;
 }
 
+/**
+ * Returns `document.forms` from the global context.
+ * @returns {unknown}
+ */
 export function forms() {
   return (globalThis).document?.forms;
 }
+/**
+ * Returns `doc.forms` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function formsFrom(doc) {
   return (doc).forms;
 }
 
+/**
+ * Returns `document.fragmentDirective` from the global context.
+ * @returns {unknown}
+ */
 export function fragmentDirective() {
   return (globalThis).document?.fragmentDirective;
 }
+/**
+ * Returns `doc.fragmentDirective` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function fragmentDirectiveFrom(doc) {
   return (doc).fragmentDirective;
 }
 
+/**
+ * Returns `document.fullscreenElement` from the global context.
+ * @returns {unknown}
+ */
 export function fullscreenElement() {
   return (globalThis).document?.fullscreenElement;
 }
+/**
+ * Returns `doc.fullscreenElement` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function fullscreenElementFrom(doc) {
   return (doc).fullscreenElement;
 }
 
+/**
+ * Returns `document.fullscreenEnabled` from the global context.
+ * @returns {unknown}
+ */
 export function fullscreenEnabled() {
   return (globalThis).document?.fullscreenEnabled;
 }
+/**
+ * Returns `doc.fullscreenEnabled` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function fullscreenEnabledFrom(doc) {
   return (doc).fullscreenEnabled;
 }
 
+/**
+ * Calls `document.getAnimations()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getAnimations(...args) {
   return (globalThis).document?.getAnimations(...args);
 }
+/**
+ * Calls `doc.getAnimations()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getAnimationsFrom(doc, ...args) {
   return (doc).getAnimations(...args);
 }
 
+/**
+ * Calls `document.getElementById()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementById(...args) {
   return (globalThis).document?.getElementById(...args);
 }
+/**
+ * Calls `doc.getElementById()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementByIdFrom(doc, ...args) {
   return (doc).getElementById(...args);
 }
 
+/**
+ * Calls `document.getElementsByClassName()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementsByClassName(...args) {
   return (globalThis).document?.getElementsByClassName(...args);
 }
+/**
+ * Calls `doc.getElementsByClassName()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementsByClassNameFrom(doc, ...args) {
   return (doc).getElementsByClassName(...args);
 }
 
+/**
+ * Calls `document.getElementsByName()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementsByName(...args) {
   return (globalThis).document?.getElementsByName(...args);
 }
+/**
+ * Calls `doc.getElementsByName()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementsByNameFrom(doc, ...args) {
   return (doc).getElementsByName(...args);
 }
 
+/**
+ * Calls `document.getElementsByTagName()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementsByTagName(...args) {
   return (globalThis).document?.getElementsByTagName(...args);
 }
+/**
+ * Calls `doc.getElementsByTagName()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementsByTagNameFrom(doc, ...args) {
   return (doc).getElementsByTagName(...args);
 }
 
+/**
+ * Calls `document.getElementsByTagNameNS()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementsByTagNameNS(...args) {
   return (globalThis).document?.getElementsByTagNameNS(...args);
 }
+/**
+ * Calls `doc.getElementsByTagNameNS()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getElementsByTagNameNSFrom(doc, ...args) {
   return (doc).getElementsByTagNameNS(...args);
 }
 
+/**
+ * Calls `document.getSelection()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getSelection(...args) {
   return (globalThis).document?.getSelection(...args);
 }
+/**
+ * Calls `doc.getSelection()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getSelectionFrom(doc, ...args) {
   return (doc).getSelection(...args);
 }
 
+/**
+ * Calls `document.hasFocus()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function hasFocus(...args) {
   return (globalThis).document?.hasFocus(...args);
 }
+/**
+ * Calls `doc.hasFocus()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function hasFocusFrom(doc, ...args) {
   return (doc).hasFocus(...args);
 }
 
+/**
+ * Calls `document.hasStorageAccess()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function hasStorageAccess(...args) {
   return (globalThis).document?.hasStorageAccess(...args);
 }
+/**
+ * Calls `doc.hasStorageAccess()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function hasStorageAccessFrom(doc, ...args) {
   return (doc).hasStorageAccess(...args);
 }
 
+/**
+ * Calls `document.hasUnpartitionedCookieAccess()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function hasUnpartitionedCookieAccess(...args) {
   return (globalThis).document?.hasUnpartitionedCookieAccess(...args);
 }
+/**
+ * Calls `doc.hasUnpartitionedCookieAccess()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function hasUnpartitionedCookieAccessFrom(doc, ...args) {
   return (doc).hasUnpartitionedCookieAccess(...args);
 }
 
+/**
+ * Returns `document.head` from the global context.
+ * @returns {unknown}
+ */
 export function head() {
   return (globalThis).document?.head;
 }
+/**
+ * Returns `doc.head` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function headFrom(doc) {
   return (doc).head;
 }
 
+/**
+ * Returns `document.hidden` from the global context.
+ * @returns {unknown}
+ */
 export function hidden() {
   return (globalThis).document?.hidden;
 }
+/**
+ * Returns `doc.hidden` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function hiddenFrom(doc) {
   return (doc).hidden;
 }
 
+/**
+ * Returns `document.images` from the global context.
+ * @returns {unknown}
+ */
 export function images() {
   return (globalThis).document?.images;
 }
+/**
+ * Returns `doc.images` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function imagesFrom(doc) {
   return (doc).images;
 }
 
+/**
+ * Returns `document.implementation` from the global context.
+ * @returns {unknown}
+ */
 export function implementation() {
   return (globalThis).document?.implementation;
 }
+/**
+ * Returns `doc.implementation` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function implementationFrom(doc) {
   return (doc).implementation;
 }
 
+/**
+ * Calls `document.importNode()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function importNode(...args) {
   return (globalThis).document?.importNode(...args);
 }
+/**
+ * Calls `doc.importNode()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function importNodeFrom(doc, ...args) {
   return (doc).importNode(...args);
 }
 
+/**
+ * Returns `document.lastElementChild` from the global context.
+ * @returns {unknown}
+ */
 export function lastElementChild() {
   return (globalThis).document?.lastElementChild;
 }
+/**
+ * Returns `doc.lastElementChild` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function lastElementChildFrom(doc) {
   return (doc).lastElementChild;
 }
 
+/**
+ * Returns `document.lastModified` from the global context.
+ * @returns {unknown}
+ */
 export function lastModified() {
   return (globalThis).document?.lastModified;
 }
+/**
+ * Returns `doc.lastModified` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function lastModifiedFrom(doc) {
   return (doc).lastModified;
 }
 
+/**
+ * Returns `document.links` from the global context.
+ * @returns {unknown}
+ */
 export function links() {
   return (globalThis).document?.links;
 }
+/**
+ * Returns `doc.links` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function linksFrom(doc) {
   return (doc).links;
 }
 
+/**
+ * Returns `document.location` from the global context.
+ * @returns {unknown}
+ */
 export function location() {
   return (globalThis).document?.location;
 }
+/**
+ * Returns `doc.location` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function locationFrom(doc) {
   return (doc).location;
 }
 
+/**
+ * Calls `document.moveBefore()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function moveBefore(...args) {
   return (globalThis).document?.moveBefore(...args);
 }
+/**
+ * Calls `doc.moveBefore()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function moveBeforeFrom(doc, ...args) {
   return (doc).moveBefore(...args);
 }
 
+/**
+ * Calls `document.mozSetImageElement()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function mozSetImageElement(...args) {
   return (globalThis).document?.mozSetImageElement(...args);
 }
+/**
+ * Calls `doc.mozSetImageElement()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function mozSetImageElementFrom(doc, ...args) {
   return (doc).mozSetImageElement(...args);
 }
 
+/**
+ * Calls `document.open()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function open(...args) {
   return (globalThis).document?.open(...args);
 }
+/**
+ * Calls `doc.open()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function openFrom(doc, ...args) {
   return (doc).open(...args);
 }
 
+/**
+ * Returns `document.pictureInPictureElement` from the global context.
+ * @returns {unknown}
+ */
 export function pictureInPictureElement() {
   return (globalThis).document?.pictureInPictureElement;
 }
+/**
+ * Returns `doc.pictureInPictureElement` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function pictureInPictureElementFrom(doc) {
   return (doc).pictureInPictureElement;
 }
 
+/**
+ * Returns `document.pictureInPictureEnabled` from the global context.
+ * @returns {unknown}
+ */
 export function pictureInPictureEnabled() {
   return (globalThis).document?.pictureInPictureEnabled;
 }
+/**
+ * Returns `doc.pictureInPictureEnabled` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function pictureInPictureEnabledFrom(doc) {
   return (doc).pictureInPictureEnabled;
 }
 
+/**
+ * Returns `document.plugins` from the global context.
+ * @returns {unknown}
+ */
 export function plugins() {
   return (globalThis).document?.plugins;
 }
+/**
+ * Returns `doc.plugins` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function pluginsFrom(doc) {
   return (doc).plugins;
 }
 
+/**
+ * Returns `document.pointerLockElement` from the global context.
+ * @returns {unknown}
+ */
 export function pointerLockElement() {
   return (globalThis).document?.pointerLockElement;
 }
+/**
+ * Returns `doc.pointerLockElement` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function pointerLockElementFrom(doc) {
   return (doc).pointerLockElement;
 }
 
+/**
+ * Calls `document.prepend()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function prepend(...args) {
   return (globalThis).document?.prepend(...args);
 }
+/**
+ * Calls `doc.prepend()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function prependFrom(doc, ...args) {
   return (doc).prepend(...args);
 }
 
+/**
+ * Returns `document.prerendering` from the global context.
+ * @returns {unknown}
+ */
 export function prerendering() {
   return (globalThis).document?.prerendering;
 }
+/**
+ * Returns `doc.prerendering` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function prerenderingFrom(doc) {
   return (doc).prerendering;
 }
 
+/**
+ * Calls `document.queryCommandEnabled()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queryCommandEnabled(...args) {
   return (globalThis).document?.queryCommandEnabled(...args);
 }
+/**
+ * Calls `doc.queryCommandEnabled()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queryCommandEnabledFrom(doc, ...args) {
   return (doc).queryCommandEnabled(...args);
 }
 
+/**
+ * Calls `document.queryCommandState()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queryCommandState(...args) {
   return (globalThis).document?.queryCommandState(...args);
 }
+/**
+ * Calls `doc.queryCommandState()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queryCommandStateFrom(doc, ...args) {
   return (doc).queryCommandState(...args);
 }
 
+/**
+ * Calls `document.queryCommandSupported()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queryCommandSupported(...args) {
   return (globalThis).document?.queryCommandSupported(...args);
 }
+/**
+ * Calls `doc.queryCommandSupported()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queryCommandSupportedFrom(doc, ...args) {
   return (doc).queryCommandSupported(...args);
 }
 
+/**
+ * Calls `document.querySelector()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function querySelector(...args) {
   return (globalThis).document?.querySelector(...args);
 }
+/**
+ * Calls `doc.querySelector()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function querySelectorFrom(doc, ...args) {
   return (doc).querySelector(...args);
 }
 
+/**
+ * Calls `document.querySelectorAll()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function querySelectorAll(...args) {
   return (globalThis).document?.querySelectorAll(...args);
 }
+/**
+ * Calls `doc.querySelectorAll()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function querySelectorAllFrom(doc, ...args) {
   return (doc).querySelectorAll(...args);
 }
 
+/**
+ * Returns `document.readyState` from the global context.
+ * @returns {unknown}
+ */
 export function readyState() {
   return (globalThis).document?.readyState;
 }
+/**
+ * Returns `doc.readyState` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function readyStateFrom(doc) {
   return (doc).readyState;
 }
 
+/**
+ * Returns `document.referrer` from the global context.
+ * @returns {unknown}
+ */
 export function referrer() {
   return (globalThis).document?.referrer;
 }
+/**
+ * Returns `doc.referrer` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function referrerFrom(doc) {
   return (doc).referrer;
 }
 
+/**
+ * Calls `document.releaseCapture()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function releaseCapture(...args) {
   return (globalThis).document?.releaseCapture(...args);
 }
+/**
+ * Calls `doc.releaseCapture()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function releaseCaptureFrom(doc, ...args) {
   return (doc).releaseCapture(...args);
 }
 
+/**
+ * Calls `document.replaceChildren()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function replaceChildren(...args) {
   return (globalThis).document?.replaceChildren(...args);
 }
+/**
+ * Calls `doc.replaceChildren()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function replaceChildrenFrom(doc, ...args) {
   return (doc).replaceChildren(...args);
 }
 
+/**
+ * Calls `document.requestStorageAccess()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function requestStorageAccess(...args) {
   return (globalThis).document?.requestStorageAccess(...args);
 }
+/**
+ * Calls `doc.requestStorageAccess()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function requestStorageAccessFrom(doc, ...args) {
   return (doc).requestStorageAccess(...args);
 }
 
+/**
+ * Calls `document.requestStorageAccessFor()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function requestStorageAccessFor(...args) {
   return (globalThis).document?.requestStorageAccessFor(...args);
 }
+/**
+ * Calls `doc.requestStorageAccessFor()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function requestStorageAccessForFrom(doc, ...args) {
   return (doc).requestStorageAccessFor(...args);
 }
 
+/**
+ * Returns `document.scripts` from the global context.
+ * @returns {unknown}
+ */
 export function scripts() {
   return (globalThis).document?.scripts;
 }
+/**
+ * Returns `doc.scripts` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function scriptsFrom(doc) {
   return (doc).scripts;
 }
 
+/**
+ * Returns `document.scrollingElement` from the global context.
+ * @returns {unknown}
+ */
 export function scrollingElement() {
   return (globalThis).document?.scrollingElement;
 }
+/**
+ * Returns `doc.scrollingElement` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function scrollingElementFrom(doc) {
   return (doc).scrollingElement;
 }
 
+/**
+ * Calls `document.startViewTransition()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function startViewTransition(...args) {
   return (globalThis).document?.startViewTransition(...args);
 }
+/**
+ * Calls `doc.startViewTransition()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function startViewTransitionFrom(doc, ...args) {
   return (doc).startViewTransition(...args);
 }
 
+/**
+ * Returns `document.styleSheets` from the global context.
+ * @returns {unknown}
+ */
 export function styleSheets() {
   return (globalThis).document?.styleSheets;
 }
+/**
+ * Returns `doc.styleSheets` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function styleSheetsFrom(doc) {
   return (doc).styleSheets;
 }
 
+/**
+ * Returns `document.timeline` from the global context.
+ * @returns {unknown}
+ */
 export function timeline() {
   return (globalThis).document?.timeline;
 }
+/**
+ * Returns `doc.timeline` from the provided document.
+ * @param {Document} doc
+ * @returns {unknown}
+ */
 export function timelineFrom(doc) {
   return (doc).timeline;
 }
 
+/**
+ * Returns `document.title` from the global context.
+ * @returns {(string|undefined)}
+ */
 export function title() {
   return (globalThis).document?.title;
 }
+/**
+ * Returns `doc.title` from the provided document.
+ * @param {Document} doc
+ * @returns {(string|undefined)}
+ */
 export function titleFrom(doc) {
   return (doc).title;
 }
 
+/**
+ * Returns `document.URL` from the global context.
+ * @returns {(string|undefined)}
+ */
 export function URL() {
   return (globalThis).document?.URL;
 }
+/**
+ * Returns `doc.URL` from the provided document.
+ * @param {Document} doc
+ * @returns {(string|undefined)}
+ */
 export function URLFrom(doc) {
   return (doc).URL;
 }
 
+/**
+ * Returns `document.visibilityState` from the global context.
+ * @returns {(string|undefined)}
+ */
 export function visibilityState() {
   return (globalThis).document?.visibilityState;
 }
+/**
+ * Returns `doc.visibilityState` from the provided document.
+ * @param {Document} doc
+ * @returns {(string|undefined)}
+ */
 export function visibilityStateFrom(doc) {
   return (doc).visibilityState;
 }
 
+/**
+ * Calls `document.write()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function write(...args) {
   return (globalThis).document?.write(...args);
 }
+/**
+ * Calls `doc.write()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function writeFrom(doc, ...args) {
   return (doc).write(...args);
 }
 
+/**
+ * Calls `document.writeln()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function writeln(...args) {
   return (globalThis).document?.writeln(...args);
 }
+/**
+ * Calls `doc.writeln()` on the provided document.
+ * @param {Document} doc
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function writelnFrom(doc, ...args) {
   return (doc).writeln(...args);
 }

--- a/src/event_target.ffi.mjs
+++ b/src/event_target.ffi.mjs
@@ -1,20 +1,53 @@
+/**
+ * Calls `window.addEventListener()` from the global context.
+ * @param {...any} args
+ * @returns {void}
+ */
 export function addEventListener(...args) {
   return (globalThis).addEventListener(...args);
 }
+/**
+ * Calls `target.addEventListener()` on the provided target.
+ * @param {EventTarget} target
+ * @param {...any} args
+ * @returns {void}
+ */
 export function addEventListenerTo(target, ...args) {
   return (target).addEventListener(...args);
 }
 
+/**
+ * Calls `globalThis.dispatchEvent()` from the global context.
+ * @param {...any} args
+ * @returns {boolean}
+ */
 export function dispatchEvent(...args) {
   return (globalThis).dispatchEvent(...args);
 }
+/**
+ * Calls `target.dispatchEvent()` on the provided target.
+ * @param {EventTarget} target
+ * @param {...any} args
+ * @returns {boolean}
+ */
 export function dispatchEventTo(target, ...args) {
   return (target).dispatchEvent(...args);
 }
 
+/**
+ * Calls `globalThis.removeEventListener()` from the global context.
+ * @param {...any} args
+ * @returns {void}
+ */
 export function removeEventListener(...args) {
   return (globalThis).removeEventListener(...args);
 }
+/**
+ * Calls `target.removeEventListener()` on the provided target.
+ * @param {EventTarget} target
+ * @param {...any} args
+ * @returns {void}
+ */
 export function removeEventListenerFrom(target, ...args) {
   return (target).removeEventListener(...args);
 }

--- a/src/window.ffi.mjs
+++ b/src/window.ffi.mjs
@@ -1,761 +1,1836 @@
+/**
+ * Calls `globalThis.alert()` from the global context.
+ * @param {...any} args
+ * @returns {void}
+ */
 export function alert(...args) {
   return (globalThis).alert(...args);
 }
+/**
+ * Calls `win.alert()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {void}
+ */
 export function alertFrom(win, ...args) {
   return (win).alert(...args);
 }
 
+/**
+ * Calls `globalThis.atob()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function atob(...args) {
   return (globalThis).atob(...args);
 }
+/**
+ * Calls `win.atob()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function atobFrom(win, ...args) {
   return (win).atob(...args);
 }
 
+/**
+ * Calls `globalThis.blur()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function blur(...args) {
   return (globalThis).blur(...args);
 }
+/**
+ * Calls `win.blur()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function blurFrom(win, ...args) {
   return (win).blur(...args);
 }
 
+/**
+ * Calls `globalThis.btoa()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function btoa(...args) {
   return (globalThis).btoa(...args);
 }
+/**
+ * Calls `win.btoa()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function btoaFrom(win, ...args) {
   return (win).btoa(...args);
 }
 
+/**
+ * Returns `globalThis.caches` from the global context.
+ * @returns {unknown}
+ */
 export function caches() {
   return (globalThis).caches;
 }
+/**
+ * Returns `win.caches` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function cachesFrom(win) {
   return (win).caches;
 }
 
+/**
+ * Calls `globalThis.cancelAnimationFrame()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function cancelAnimationFrame(...args) {
   return (globalThis).cancelAnimationFrame(...args);
 }
+/**
+ * Calls `win.cancelAnimationFrame()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function cancelAnimationFrameFrom(win, ...args) {
   return (win).cancelAnimationFrame(...args);
 }
 
+/**
+ * Calls `globalThis.cancelIdleCallback()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function cancelIdleCallback(...args) {
   return (globalThis).cancelIdleCallback(...args);
 }
+/**
+ * Calls `win.cancelIdleCallback()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function cancelIdleCallbackFrom(win, ...args) {
   return (win).cancelIdleCallback(...args);
 }
 
+/**
+ * Calls `globalThis.clearInterval()` from the global context.
+ * @param {...any} args
+ * @returns {void}
+ */
 export function clearInterval(...args) {
   return (globalThis).clearInterval(...args);
 }
+/**
+ * Calls `win.clearInterval()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {void}
+ */
 export function clearIntervalFrom(win, ...args) {
   return (win).clearInterval(...args);
 }
 
+/**
+ * Calls `globalThis.clearTimeout()` from the global context.
+ * @param {...any} args
+ * @returns {void}
+ */
 export function clearTimeout(...args) {
   return (globalThis).clearTimeout(...args);
 }
+/**
+ * Calls `win.clearTimeout()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {void}
+ */
 export function clearTimeoutFrom(win, ...args) {
   return (win).clearTimeout(...args);
 }
 
+/**
+ * Returns `globalThis.clientInformation` from the global context.
+ * @returns {unknown}
+ */
 export function clientInformation() {
   return (globalThis).clientInformation;
 }
+/**
+ * Returns `win.clientInformation` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function clientInformationFrom(win) {
   return (win).clientInformation;
 }
 
+/**
+ * Calls `globalThis.close()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function close(...args) {
   return (globalThis).close(...args);
 }
+/**
+ * Calls `win.close()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function closeFrom(win, ...args) {
   return (win).close(...args);
 }
 
+/**
+ * Returns `globalThis.closed` from the global context.
+ * @returns {unknown}
+ */
 export function closed() {
   return (globalThis).closed;
 }
+/**
+ * Returns `win.closed` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function closedFrom(win) {
   return (win).closed;
 }
 
+/**
+ * Calls `globalThis.confirm()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function confirm(...args) {
   return (globalThis).confirm(...args);
 }
+/**
+ * Calls `win.confirm()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function confirmFrom(win, ...args) {
   return (win).confirm(...args);
 }
 
+/**
+ * Returns `globalThis.cookieStore` from the global context.
+ * @returns {(string|undefined)}
+ */
 export function cookieStore() {
   return (globalThis).cookieStore;
 }
+/**
+ * Returns `win.cookieStore` from the provided window.
+ * @param {Window} win
+ * @returns {(string|undefined)}
+ */
 export function cookieStoreFrom(win) {
   return (win).cookieStore;
 }
 
+/**
+ * Calls `globalThis.createImageBitmap()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createImageBitmap(...args) {
   return (globalThis).createImageBitmap(...args);
 }
+/**
+ * Calls `win.createImageBitmap()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function createImageBitmapFrom(win, ...args) {
   return (win).createImageBitmap(...args);
 }
 
+/**
+ * Returns `globalThis.credentialless` from the global context.
+ * @returns {unknown}
+ */
 export function credentialless() {
   return (globalThis).credentialless;
 }
+/**
+ * Returns `win.credentialless` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function credentiallessFrom(win) {
   return (win).credentialless;
 }
 
+/**
+ * Returns `globalThis.crossOriginIsolated` from the global context.
+ * @returns {unknown}
+ */
 export function crossOriginIsolated() {
   return (globalThis).crossOriginIsolated;
 }
+/**
+ * Returns `win.crossOriginIsolated` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function crossOriginIsolatedFrom(win) {
   return (win).crossOriginIsolated;
 }
 
+/**
+ * Returns `globalThis.crypto` from the global context.
+ * @returns {unknown}
+ */
 export function crypto() {
   return (globalThis).crypto;
 }
+/**
+ * Returns `win.crypto` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function cryptoFrom(win) {
   return (win).crypto;
 }
 
+/**
+ * Returns `globalThis.customElements` from the global context.
+ * @returns {unknown}
+ */
 export function customElements() {
   return (globalThis).customElements;
 }
+/**
+ * Returns `win.customElements` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function customElementsFrom(win) {
   return (win).customElements;
 }
 
+/**
+ * Returns `globalThis.devicePixelRatio` from the global context.
+ * @returns {unknown}
+ */
 export function devicePixelRatio() {
   return (globalThis).devicePixelRatio;
 }
+/**
+ * Returns `win.devicePixelRatio` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function devicePixelRatioFrom(win) {
   return (win).devicePixelRatio;
 }
 
+/**
+ * Returns `document.document` from the global context.
+ * @returns {unknown}
+ */
 export function document() {
   return (globalThis).document;
 }
+/**
+ * Returns `doc.document` from the provided document.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function documentFrom(win) {
   return (win).document;
 }
 
+/**
+ * Returns `document.documentPictureInPicture` from the global context.
+ * @returns {unknown}
+ */
 export function documentPictureInPicture() {
   return (globalThis).documentPictureInPicture;
 }
+/**
+ * Returns `doc.documentPictureInPicture` from the provided document.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function documentPictureInPictureFrom(win) {
   return (win).documentPictureInPicture;
 }
 
+/**
+ * Calls `globalThis.dump()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function dump(...args) {
   return (globalThis).dump(...args);
 }
+/**
+ * Calls `win.dump()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function dumpFrom(win, ...args) {
   return (win).dump(...args);
 }
 
+/**
+ * Returns `globalThis.fence` from the global context.
+ * @returns {unknown}
+ */
 export function fence() {
   return (globalThis).fence;
 }
+/**
+ * Returns `win.fence` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function fenceFrom(win) {
   return (win).fence;
 }
 
+/**
+ * Calls `globalThis.fetch()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function fetch(...args) {
   return (globalThis).fetch(...args);
 }
+/**
+ * Calls `win.fetch()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function fetchFrom(win, ...args) {
   return (win).fetch(...args);
 }
 
+/**
+ * Calls `globalThis.fetchLater()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function fetchLater(...args) {
   return (globalThis).fetchLater(...args);
 }
+/**
+ * Calls `win.fetchLater()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function fetchLaterFrom(win, ...args) {
   return (win).fetchLater(...args);
 }
 
+/**
+ * Calls `globalThis.find()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function find(...args) {
   return (globalThis).find(...args);
 }
+/**
+ * Calls `win.find()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function findFrom(win, ...args) {
   return (win).find(...args);
 }
 
+/**
+ * Calls `globalThis.focus()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function focus(...args) {
   return (globalThis).focus(...args);
 }
+/**
+ * Calls `win.focus()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function focusFrom(win, ...args) {
   return (win).focus(...args);
 }
 
+/**
+ * Returns `globalThis.frameElement` from the global context.
+ * @returns {unknown}
+ */
 export function frameElement() {
   return (globalThis).frameElement;
 }
+/**
+ * Returns `win.frameElement` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function frameElementFrom(win) {
   return (win).frameElement;
 }
 
+/**
+ * Returns `globalThis.frames` from the global context.
+ * @returns {unknown}
+ */
 export function frames() {
   return (globalThis).frames;
 }
+/**
+ * Returns `win.frames` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function framesFrom(win) {
   return (win).frames;
 }
 
+/**
+ * Returns `globalThis.fullScreen` from the global context.
+ * @returns {unknown}
+ */
 export function fullScreen() {
   return (globalThis).fullScreen;
 }
+/**
+ * Returns `win.fullScreen` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function fullScreenFrom(win) {
   return (win).fullScreen;
 }
 
+/**
+ * Calls `globalThis.getComputedStyle()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getComputedStyle(...args) {
   return (globalThis).getComputedStyle(...args);
 }
+/**
+ * Calls `win.getComputedStyle()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getComputedStyleFrom(win, ...args) {
   return (win).getComputedStyle(...args);
 }
 
+/**
+ * Calls `globalThis.getDefaultComputedStyle()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getDefaultComputedStyle(...args) {
   return (globalThis).getDefaultComputedStyle(...args);
 }
+/**
+ * Calls `win.getDefaultComputedStyle()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getDefaultComputedStyleFrom(win, ...args) {
   return (win).getDefaultComputedStyle(...args);
 }
 
+/**
+ * Calls `globalThis.getScreenDetails()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getScreenDetails(...args) {
   return (globalThis).getScreenDetails(...args);
 }
+/**
+ * Calls `win.getScreenDetails()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getScreenDetailsFrom(win, ...args) {
   return (win).getScreenDetails(...args);
 }
 
+/**
+ * Calls `globalThis.getSelection()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getSelection(...args) {
   return (globalThis).getSelection(...args);
 }
+/**
+ * Calls `win.getSelection()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function getSelectionFrom(win, ...args) {
   return (win).getSelection(...args);
 }
 
+/**
+ * Returns `globalThis.history` from the global context.
+ * @returns {unknown}
+ */
 export function history() {
   return (globalThis).history;
 }
+/**
+ * Returns `win.history` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function historyFrom(win) {
   return (win).history;
 }
 
+/**
+ * Returns `globalThis.indexedDb` from the global context.
+ * @returns {unknown}
+ */
 export function indexedDb() {
   return (globalThis).indexedDB;
 }
+/**
+ * Returns `win.indexedDb` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function indexedDbFrom(win) {
   return (win).indexedDB;
 }
 
+/**
+ * Returns `globalThis.innerHeight` from the global context.
+ * @returns {unknown}
+ */
 export function innerHeight() {
   return (globalThis).innerHeight;
 }
+/**
+ * Returns `win.innerHeight` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function innerHeightFrom(win) {
   return (win).innerHeight;
 }
 
+/**
+ * Returns `globalThis.innerWidth` from the global context.
+ * @returns {unknown}
+ */
 export function innerWidth() {
   return (globalThis).innerWidth;
 }
+/**
+ * Returns `win.innerWidth` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function innerWidthFrom(win) {
   return (win).innerWidth;
 }
 
+/**
+ * Returns `globalThis.isSecureContext` from the global context.
+ * @returns {unknown}
+ */
 export function isSecureContext() {
   return (globalThis).isSecureContext;
 }
+/**
+ * Returns `win.isSecureContext` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function isSecureContextFrom(win) {
   return (win).isSecureContext;
 }
 
+/**
+ * Returns `globalThis.launchQueue` from the global context.
+ * @returns {unknown}
+ */
 export function launchQueue() {
   return (globalThis).launchQueue;
 }
+/**
+ * Returns `win.launchQueue` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function launchQueueFrom(win) {
   return (win).launchQueue;
 }
 
+/**
+ * Returns `globalThis.length` from the global context.
+ * @returns {unknown}
+ */
 export function length() {
   return (globalThis).length;
 }
+/**
+ * Returns `win.length` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function lengthFrom(win) {
   return (win).length;
 }
 
+/**
+ * Returns `globalThis.localStorage` from the global context.
+ * @returns {unknown}
+ */
 export function localStorage() {
   return (globalThis).localStorage;
 }
+/**
+ * Returns `win.localStorage` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function localStorageFrom(win) {
   return (win).localStorage;
 }
 
+/**
+ * Returns `globalThis.location` from the global context.
+ * @returns {unknown}
+ */
 export function location() {
   return (globalThis).location;
 }
+/**
+ * Returns `win.location` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function locationFrom(win) {
   return (win).location;
 }
 
+/**
+ * Returns `globalThis.locationbar` from the global context.
+ * @returns {unknown}
+ */
 export function locationbar() {
   return (globalThis).locationbar;
 }
+/**
+ * Returns `win.locationbar` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function locationbarFrom(win) {
   return (win).locationbar;
 }
 
+/**
+ * Calls `globalThis.matchMedia()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function matchMedia(...args) {
   return (globalThis).matchMedia(...args);
 }
+/**
+ * Calls `win.matchMedia()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function matchMediaFrom(win, ...args) {
   return (win).matchMedia(...args);
 }
 
+/**
+ * Returns `globalThis.menubar` from the global context.
+ * @returns {unknown}
+ */
 export function menubar() {
   return (globalThis).menubar;
 }
+/**
+ * Returns `win.menubar` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function menubarFrom(win) {
   return (win).menubar;
 }
 
+/**
+ * Calls `globalThis.moveBy()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function moveBy(...args) {
   return (globalThis).moveBy(...args);
 }
+/**
+ * Calls `win.moveBy()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function moveByFrom(win, ...args) {
   return (win).moveBy(...args);
 }
 
+/**
+ * Calls `globalThis.move()` on the provided target.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function moveTo(...args) {
   return (globalThis).moveTo(...args);
 }
+/**
+ * Calls `win.moveTo()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function moveToFrom(win, ...args) {
   return (win).moveTo(...args);
 }
 
+/**
+ * Returns `globalThis.mozInnerScreenX` from the global context.
+ * @returns {unknown}
+ */
 export function mozInnerScreenX() {
   return (globalThis).mozInnerScreenX;
 }
+/**
+ * Returns `win.mozInnerScreenX` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function mozInnerScreenXFrom(win) {
   return (win).mozInnerScreenX;
 }
 
+/**
+ * Returns `globalThis.mozInnerScreenY` from the global context.
+ * @returns {unknown}
+ */
 export function mozInnerScreenY() {
   return (globalThis).mozInnerScreenY;
 }
+/**
+ * Returns `win.mozInnerScreenY` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function mozInnerScreenYFrom(win) {
   return (win).mozInnerScreenY;
 }
 
+/**
+ * Returns `globalThis.name` from the global context.
+ * @returns {unknown}
+ */
 export function name() {
   return (globalThis).name;
 }
+/**
+ * Returns `win.name` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function nameFrom(win) {
   return (win).name;
 }
 
+/**
+ * Returns `globalThis.navigation` from the global context.
+ * @returns {unknown}
+ */
 export function navigation() {
   return (globalThis).navigation;
 }
+/**
+ * Returns `win.navigation` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function navigationFrom(win) {
   return (win).navigation;
 }
 
+/**
+ * Returns `globalThis.navigator` from the global context.
+ * @returns {unknown}
+ */
 export function navigator() {
   return (globalThis).navigator;
 }
+/**
+ * Returns `win.navigator` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function navigatorFrom(win) {
   return (win).navigator;
 }
 
+/**
+ * Calls `globalThis.open()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function open(...args) {
   return (globalThis).open(...args);
 }
+/**
+ * Calls `win.open()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function openFrom(win, ...args) {
   return (win).open(...args);
 }
 
+/**
+ * Returns `globalThis.opener` from the global context.
+ * @returns {unknown}
+ */
 export function opener() {
   return (globalThis).opener;
 }
+/**
+ * Returns `win.opener` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function openerFrom(win) {
   return (win).opener;
 }
 
+/**
+ * Returns `globalThis.origin` from the global context.
+ * @returns {unknown}
+ */
 export function origin() {
   return (globalThis).origin;
 }
+/**
+ * Returns `win.origin` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function originFrom(win) {
   return (win).origin;
 }
 
+/**
+ * Returns `globalThis.originAgentCluster` from the global context.
+ * @returns {unknown}
+ */
 export function originAgentCluster() {
   return (globalThis).originAgentCluster;
 }
+/**
+ * Returns `win.originAgentCluster` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function originAgentClusterFrom(win) {
   return (win).originAgentCluster;
 }
 
+/**
+ * Returns `globalThis.outerHeight` from the global context.
+ * @returns {unknown}
+ */
 export function outerHeight() {
   return (globalThis).outerHeight;
 }
+/**
+ * Returns `win.outerHeight` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function outerHeightFrom(win) {
   return (win).outerHeight;
 }
 
+/**
+ * Returns `globalThis.outerWidth` from the global context.
+ * @returns {unknown}
+ */
 export function outerWidth() {
   return (globalThis).outerWidth;
 }
+/**
+ * Returns `win.outerWidth` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function outerWidthFrom(win) {
   return (win).outerWidth;
 }
 
+/**
+ * Returns `globalThis.pageXOffset` from the global context.
+ * @returns {unknown}
+ */
 export function pageXOffset() {
   return (globalThis).pageXOffset;
 }
+/**
+ * Returns `win.pageXOffset` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function pageXOffsetFrom(win) {
   return (win).pageXOffset;
 }
 
+/**
+ * Returns `globalThis.pageYOffset` from the global context.
+ * @returns {unknown}
+ */
 export function pageYOffset() {
   return (globalThis).pageYOffset;
 }
+/**
+ * Returns `win.pageYOffset` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function pageYOffsetFrom(win) {
   return (win).pageYOffset;
 }
 
+/**
+ * Returns `globalThis.parent` from the global context.
+ * @returns {unknown}
+ */
 export function parent() {
   return (globalThis).parent;
 }
+/**
+ * Returns `win.parent` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function parentFrom(win) {
   return (win).parent;
 }
 
+/**
+ * Returns `globalThis.performance` from the global context.
+ * @returns {unknown}
+ */
 export function performance() {
   return (globalThis).performance;
 }
+/**
+ * Returns `win.performance` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function performanceFrom(win) {
   return (win).performance;
 }
 
+/**
+ * Returns `globalThis.personalbar` from the global context.
+ * @returns {unknown}
+ */
 export function personalbar() {
   return (globalThis).personalbar;
 }
+/**
+ * Returns `win.personalbar` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function personalbarFrom(win) {
   return (win).personalbar;
 }
 
+/**
+ * Calls `globalThis.postMessage()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function postMessage(...args) {
   return (globalThis).postMessage(...args);
 }
+/**
+ * Calls `win.postMessage()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function postMessageFrom(win, ...args) {
   return (win).postMessage(...args);
 }
 
+/**
+ * Calls `globalThis.print()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function print(...args) {
   return (globalThis).print(...args);
 }
+/**
+ * Calls `win.print()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function printFrom(win, ...args) {
   return (win).print(...args);
 }
 
+/**
+ * Calls `globalThis.prompt()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function prompt(...args) {
   return (globalThis).prompt(...args);
 }
+/**
+ * Calls `win.prompt()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function promptFrom(win, ...args) {
   return (win).prompt(...args);
 }
 
+/**
+ * Calls `globalThis.queryLocalFonts()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queryLocalFonts(...args) {
   return (globalThis).queryLocalFonts(...args);
 }
+/**
+ * Calls `win.queryLocalFonts()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queryLocalFontsFrom(win, ...args) {
   return (win).queryLocalFonts(...args);
 }
 
+/**
+ * Calls `globalThis.queueMicrotask()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queueMicrotask(...args) {
   return (globalThis).queueMicrotask(...args);
 }
+/**
+ * Calls `win.queueMicrotask()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function queueMicrotaskFrom(win, ...args) {
   return (win).queueMicrotask(...args);
 }
 
+/**
+ * Calls `globalThis.reportError()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function reportError(...args) {
   return (globalThis).reportError(...args);
 }
+/**
+ * Calls `win.reportError()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function reportErrorFrom(win, ...args) {
   return (win).reportError(...args);
 }
 
+/**
+ * Calls `globalThis.requestAnimationFrame()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function requestAnimationFrame(...args) {
   return (globalThis).requestAnimationFrame(...args);
 }
+/**
+ * Calls `win.requestAnimationFrame()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function requestAnimationFrameFrom(win, ...args) {
   return (win).requestAnimationFrame(...args);
 }
 
+/**
+ * Calls `globalThis.requestIdleCallback()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function requestIdleCallback(...args) {
   return (globalThis).requestIdleCallback(...args);
 }
+/**
+ * Calls `win.requestIdleCallback()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function requestIdleCallbackFrom(win, ...args) {
   return (win).requestIdleCallback(...args);
 }
 
+/**
+ * Calls `globalThis.resizeBy()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function resizeBy(...args) {
   return (globalThis).resizeBy(...args);
 }
+/**
+ * Calls `win.resizeBy()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function resizeByFrom(win, ...args) {
   return (win).resizeBy(...args);
 }
 
+/**
+ * Calls `globalThis.resize()` on the provided target.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function resizeTo(...args) {
   return (globalThis).resizeTo(...args);
 }
+/**
+ * Calls `win.resizeTo()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function resizeToFrom(win, ...args) {
   return (win).resizeTo(...args);
 }
 
+/**
+ * Returns `globalThis.scheduler` from the global context.
+ * @returns {unknown}
+ */
 export function scheduler() {
   return (globalThis).scheduler;
 }
+/**
+ * Returns `win.scheduler` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function schedulerFrom(win) {
   return (win).scheduler;
 }
 
+/**
+ * Returns `globalThis.screen` from the global context.
+ * @returns {unknown}
+ */
 export function screen() {
   return (globalThis).screen;
 }
+/**
+ * Returns `win.screen` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function screenFrom(win) {
   return (win).screen;
 }
 
+/**
+ * Returns `globalThis.screenLeft` from the global context.
+ * @returns {unknown}
+ */
 export function screenLeft() {
   return (globalThis).screenLeft;
 }
+/**
+ * Returns `win.screenLeft` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function screenLeftFrom(win) {
   return (win).screenLeft;
 }
 
+/**
+ * Returns `globalThis.screenTop` from the global context.
+ * @returns {unknown}
+ */
 export function screenTop() {
   return (globalThis).screenTop;
 }
+/**
+ * Returns `win.screenTop` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function screenTopFrom(win) {
   return (win).screenTop;
 }
 
+/**
+ * Returns `globalThis.screenX` from the global context.
+ * @returns {unknown}
+ */
 export function screenX() {
   return (globalThis).screenX;
 }
+/**
+ * Returns `win.screenX` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function screenXFrom(win) {
   return (win).screenX;
 }
 
+/**
+ * Returns `globalThis.screenY` from the global context.
+ * @returns {unknown}
+ */
 export function screenY() {
   return (globalThis).screenY;
 }
+/**
+ * Returns `win.screenY` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function screenYFrom(win) {
   return (win).screenY;
 }
 
+/**
+ * Calls `globalThis.scroll()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scroll(...args) {
   return (globalThis).scroll(...args);
 }
+/**
+ * Calls `win.scroll()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scrollFrom(win, ...args) {
   return (win).scroll(...args);
 }
 
+/**
+ * Returns `globalThis.scrollbars` from the global context.
+ * @returns {unknown}
+ */
 export function scrollbars() {
   return (globalThis).scrollbars;
 }
+/**
+ * Returns `win.scrollbars` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function scrollbarsFrom(win) {
   return (win).scrollbars;
 }
 
+/**
+ * Calls `globalThis.scrollBy()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scrollBy(...args) {
   return (globalThis).scrollBy(...args);
 }
+/**
+ * Calls `win.scrollBy()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scrollByFrom(win, ...args) {
   return (win).scrollBy(...args);
 }
 
+/**
+ * Calls `globalThis.scrollByLines()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scrollByLines(...args) {
   return (globalThis).scrollByLines(...args);
 }
+/**
+ * Calls `win.scrollByLines()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scrollByLinesFrom(win, ...args) {
   return (win).scrollByLines(...args);
 }
 
+/**
+ * Calls `globalThis.scrollByPages()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scrollByPages(...args) {
   return (globalThis).scrollByPages(...args);
 }
+/**
+ * Calls `win.scrollByPages()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scrollByPagesFrom(win, ...args) {
   return (win).scrollByPages(...args);
 }
 
+/**
+ * Returns `globalThis.scrollMaxX` from the global context.
+ * @returns {unknown}
+ */
 export function scrollMaxX() {
   return (globalThis).scrollMaxX;
 }
+/**
+ * Returns `win.scrollMaxX` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function scrollMaxXFrom(win) {
   return (win).scrollMaxX;
 }
 
+/**
+ * Returns `globalThis.scrollMaxY` from the global context.
+ * @returns {unknown}
+ */
 export function scrollMaxY() {
   return (globalThis).scrollMaxY;
 }
+/**
+ * Returns `win.scrollMaxY` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function scrollMaxYFrom(win) {
   return (win).scrollMaxY;
 }
 
+/**
+ * Calls `globalThis.scroll()` on the provided target.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scrollTo(...args) {
   return (globalThis).scrollTo(...args);
 }
+/**
+ * Calls `win.scrollTo()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function scrollToFrom(win, ...args) {
   return (win).scrollTo(...args);
 }
 
+/**
+ * Returns `globalThis.scrollX` from the global context.
+ * @returns {unknown}
+ */
 export function scrollX() {
   return (globalThis).scrollX;
 }
+/**
+ * Returns `win.scrollX` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function scrollXFrom(win) {
   return (win).scrollX;
 }
 
+/**
+ * Returns `globalThis.scrollY` from the global context.
+ * @returns {unknown}
+ */
 export function scrollY() {
   return (globalThis).scrollY;
 }
+/**
+ * Returns `win.scrollY` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function scrollYFrom(win) {
   return (win).scrollY;
 }
 
+/**
+ * Returns `globalThis.self` from the global context.
+ * @returns {unknown}
+ */
 export function self() {
   return (globalThis).self;
 }
+/**
+ * Returns `win.self` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function selfFrom(win) {
   return (win).self;
 }
 
+/**
+ * Returns `globalThis.sessionStorage` from the global context.
+ * @returns {unknown}
+ */
 export function sessionStorage() {
   return (globalThis).sessionStorage;
 }
+/**
+ * Returns `win.sessionStorage` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function sessionStorageFrom(win) {
   return (win).sessionStorage;
 }
 
+/**
+ * Calls `globalThis.setInterval()` from the global context.
+ * @param {...any} args
+ * @returns {number}
+ */
 export function setInterval(...args) {
   return (globalThis).setInterval(...args);
 }
+/**
+ * Calls `win.setInterval()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {number}
+ */
 export function setIntervalFrom(win, ...args) {
   return (win).setInterval(...args);
 }
 
+/**
+ * Calls `globalThis.setTimeout()` from the global context.
+ * @param {...any} args
+ * @returns {number}
+ */
 export function setTimeout(...args) {
   return (globalThis).setTimeout(...args);
 }
+/**
+ * Calls `win.setTimeout()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {number}
+ */
 export function setTimeoutFrom(win, ...args) {
   return (win).setTimeout(...args);
 }
+/**
+ * Returns `globalThis.sharedStorage` from the global context.
+ * @returns {unknown}
+ */
 export function sharedStorage() {
   return (globalThis).sharedStorage;
 }
+/**
+ * Returns `win.sharedStorage` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function sharedStorageFrom(win) {
   return (win).sharedStorage;
 }
 
+/**
+ * Calls `globalThis.showDirectoryPicker()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function showDirectoryPicker(...args) {
   return (globalThis).showDirectoryPicker(...args);
 }
+/**
+ * Calls `win.showDirectoryPicker()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function showDirectoryPickerFrom(win, ...args) {
   return (win).showDirectoryPicker(...args);
 }
 
+/**
+ * Calls `globalThis.showOpenFilePicker()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function showOpenFilePicker(...args) {
   return (globalThis).showOpenFilePicker(...args);
 }
+/**
+ * Calls `win.showOpenFilePicker()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function showOpenFilePickerFrom(win, ...args) {
   return (win).showOpenFilePicker(...args);
 }
 
+/**
+ * Calls `globalThis.showSaveFilePicker()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function showSaveFilePicker(...args) {
   return (globalThis).showSaveFilePicker(...args);
 }
+/**
+ * Calls `win.showSaveFilePicker()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function showSaveFilePickerFrom(win, ...args) {
   return (win).showSaveFilePicker(...args);
 }
 
+/**
+ * Calls `globalThis.sizeToContent()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function sizeToContent(...args) {
   return (globalThis).sizeToContent(...args);
 }
+/**
+ * Calls `win.sizeToContent()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function sizeToContentFrom(win, ...args) {
   return (win).sizeToContent(...args);
 }
 
+/**
+ * Returns `globalThis.speechSynthesis` from the global context.
+ * @returns {unknown}
+ */
 export function speechSynthesis() {
   return (globalThis).speechSynthesis;
 }
+/**
+ * Returns `win.speechSynthesis` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function speechSynthesisFrom(win) {
   return (win).speechSynthesis;
 }
 
+/**
+ * Returns `globalThis.statusbar` from the global context.
+ * @returns {unknown}
+ */
 export function statusbar() {
   return (globalThis).statusbar;
 }
+/**
+ * Returns `win.statusbar` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function statusbarFrom(win) {
   return (win).statusbar;
 }
 
+/**
+ * Calls `globalThis.stop()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function stop(...args) {
   return (globalThis).stop(...args);
 }
+/**
+ * Calls `win.stop()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function stopFrom(win, ...args) {
   return (win).stop(...args);
 }
 
+/**
+ * Calls `globalThis.structuredClone()` from the global context.
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function structuredClone(...args) {
   return (globalThis).structuredClone(...args);
 }
+/**
+ * Calls `win.structuredClone()` on the provided window.
+ * @param {Window} win
+ * @param {...any} args
+ * @returns {unknown}
+ */
 export function structuredCloneFrom(win, ...args) {
   return (win).structuredClone(...args);
 }
 
+/**
+ * Returns `globalThis.toolbar` from the global context.
+ * @returns {unknown}
+ */
 export function toolbar() {
   return (globalThis).toolbar;
 }
+/**
+ * Returns `win.toolbar` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function toolbarFrom(win) {
   return (win).toolbar;
 }
 
+/**
+ * Returns `globalThis.top` from the global context.
+ * @returns {unknown}
+ */
 export function top() {
   return (globalThis).top;
 }
+/**
+ * Returns `win.top` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function topFrom(win) {
   return (win).top;
 }
 
+/**
+ * Returns `globalThis.trustedTypes` from the global context.
+ * @returns {unknown}
+ */
 export function trustedTypes() {
   return (globalThis).trustedTypes;
 }
+/**
+ * Returns `win.trustedTypes` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function trustedTypesFrom(win) {
   return (win).trustedTypes;
 }
 
+/**
+ * Returns `globalThis.visualViewport` from the global context.
+ * @returns {unknown}
+ */
 export function visualViewport() {
   return (globalThis).visualViewport;
 }
+/**
+ * Returns `win.visualViewport` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function visualViewportFrom(win) {
   return (win).visualViewport;
 }
 
+/**
+ * Returns `window.window` from the global context.
+ * @returns {unknown}
+ */
 export function window() {
   return (globalThis).window;
 }
+/**
+ * Returns `win.window` from the provided window.
+ * @param {Window} win
+ * @returns {unknown}
+ */
 export function windowFrom(win) {
   return (win).window;
 }


### PR DESCRIPTION
## Summary
- expand comments to include parameter and return types for exported wrappers
- document `addEventListener` and related event target wrappers
- document window wrapper functions like `alert`

## Testing
- `bun test`